### PR TITLE
Dgdialog import, conversion injections, Oracle service name

### DIFF
--- a/src/data/stadsdelen.conversion.json
+++ b/src/data/stadsdelen.conversion.json
@@ -1,0 +1,116 @@
+[
+  {
+    "code" : "A",
+    "identificatie" : "03630000000018",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 3
+  },
+  {
+    "code" : "B",
+    "identificatie" : "03630000000020",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 2
+  },
+  {
+    "code" : "C",
+    "identificatie" : "03630000000013",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "D",
+    "identificatie" : "03630000000009",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "E",
+    "identificatie" : "03630011872036",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 3
+  },
+  {
+    "code" : "F",
+    "identificatie" : "03630011872037",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 3
+  },
+  {
+    "code" : "G",
+    "identificatie" : "03630000000014",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "H",
+    "identificatie" : "03630000000001",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "J",
+    "identificatie" : "03630000000003",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "K",
+    "identificatie" : "03630011872038",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 3
+  },
+  {
+    "code" : "M",
+    "identificatie" : "03630011872039",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 2
+  },
+  {
+    "code" : "N",
+    "identificatie" : "03630000000019",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 2
+  },
+  {
+    "code" : "P",
+    "identificatie" : "03630000000005",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "Q",
+    "identificatie" : "03630000000008",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "R",
+    "identificatie" : "03630000000011",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "T",
+    "identificatie" : "03630000000016",
+    "registratiedatum" : "2015-01-08 15:55:55",
+    "volgnummer" : 2
+  },
+  {
+    "code" : "U",
+    "identificatie" : "03630000000007",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "V",
+    "identificatie" : "03630000000021",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  },
+  {
+    "code" : "W",
+    "identificatie" : "03630000000017",
+    "registratiedatum" : "2010-04-21 09:50:13",
+    "volgnummer" : 1
+  }
+]

--- a/src/data/stadsdelen.conversion.json
+++ b/src/data/stadsdelen.conversion.json
@@ -2,115 +2,96 @@
   {
     "code" : "A",
     "identificatie" : "03630000000018",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 3
   },
   {
     "code" : "B",
     "identificatie" : "03630000000020",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 2
   },
   {
     "code" : "C",
     "identificatie" : "03630000000013",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "D",
     "identificatie" : "03630000000009",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "E",
     "identificatie" : "03630011872036",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 3
   },
   {
     "code" : "F",
     "identificatie" : "03630011872037",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 3
   },
   {
     "code" : "G",
     "identificatie" : "03630000000014",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "H",
     "identificatie" : "03630000000001",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "J",
     "identificatie" : "03630000000003",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "K",
     "identificatie" : "03630011872038",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 3
   },
   {
     "code" : "M",
     "identificatie" : "03630011872039",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 2
   },
   {
     "code" : "N",
     "identificatie" : "03630000000019",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 2
   },
   {
     "code" : "P",
     "identificatie" : "03630000000005",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "Q",
     "identificatie" : "03630000000008",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "R",
     "identificatie" : "03630000000011",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "T",
     "identificatie" : "03630000000016",
-    "registratiedatum" : "2015-01-08 15:55:55",
     "volgnummer" : 2
   },
   {
     "code" : "U",
     "identificatie" : "03630000000007",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "V",
     "identificatie" : "03630000000021",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   },
   {
     "code" : "W",
     "identificatie" : "03630000000017",
-    "registratiedatum" : "2010-04-21 09:50:13",
     "volgnummer" : 1
   }
 ]

--- a/src/data/stadsdelen.json
+++ b/src/data/stadsdelen.json
@@ -1,0 +1,82 @@
+{
+  "version": "0.1",
+  "catalogue": "gebieden",
+  "entity": "stadsdelen",
+  "entity_id": "identificatie",
+  "source": {
+    "name": "DGDialog",
+    "entity_id": "source_id",
+    "type": "database",
+    "schema": "dgdialog",
+    "inject": {
+      "from": "data/stadsdelen.conversion.json",
+      "on": "code",
+      "conversions": {
+        "identificatie": "=",
+        "volgnummer": "+"
+      }
+    },
+    "query": [
+"    SELECT s.naam                               AS naam",
+"    ,      s.sdlcode                            AS code",
+"    ,      q1.volgnummer                        AS volgnummer",
+"    ,      to_char(q1.ingsdatum, 'YYYY-MM-DD')  AS datum_begin_geldigheid",
+"    ,      to_char(q1.einddatum, 'YYYY-MM-DD')  AS datum_einde_geldigheid",
+"    ,      to_char(s.docdatum, 'YYYY-MM-DD')    AS documentdatum",
+"    ,      s.docnr                              AS documentnummer",
+"    ,      '0363'                               AS ligt_in_gemeente",
+"    ,      t.inwin                              AS registratiedatum",
+"    ,      t.guid                               AS source_id",
+"    ,      sdo_util.to_wktgeometry(t.geometrie) AS geometrie",
+"    ,      ''                                   AS identificatie",
+"    FROM   gebieden.dgdtw_topografie t",
+"    JOIN   gebieden.dgdtw_table_6027 s ON t.id = s.dgdtw_primary_key",
+"    JOIN  (SELECT t1.id",
+"    ,      t1.guid",
+"    ,      s1.ingsdatum",
+"    ,      s1.einddatum",
+"    ,      dense_rank() OVER (partition BY s1.sdlcode ORDER BY t1.inwin) AS volgnummer",
+"    FROM   gebieden.dgdtw_topografie t1",
+"    JOIN   gebieden.dgdtw_table_6027 s1 ON t1.id = s1.dgdtw_primary_key) q1 ON t.id = q1.id",
+"    WHERE  t.objectcode = 6027 -- stadsdeel"
+     ]
+  },
+  "gob_mapping": {
+    "identificatie": {
+      "source_mapping": "identificatie"
+    },
+    "volgnummer": {
+      "source_mapping": "volgnummer"
+    },
+    "registratiedatum": {
+      "source_mapping": "registratiedatum",
+      "format": "%Y-%m-%d %H:%M:%S"
+    },
+    "naam": {
+      "source_mapping": "naam"
+    },
+    "code": {
+      "source_mapping": "code"
+    },
+    "datum_begin_geldigheid": {
+      "source_mapping": "datum_begin_geldigheid"
+    },
+    "datum_einde_geldigheid": {
+      "source_mapping": "datum_einde_geldigheid"
+    },
+    "documentdatum": {
+      "source_mapping": "documentdatum"
+    },
+    "documentnummer": {
+      "source_mapping": "documentnummer"
+    },
+    "ligt_in_gemeente": {
+      "source_mapping": {
+        "bronwaarde": "ligt_in_gemeente"
+      }
+    },
+    "geometrie": {
+      "source_mapping": "geometrie"
+    }
+  }
+}

--- a/src/gobimport/connector/config.py
+++ b/src/gobimport/connector/config.py
@@ -1,8 +1,13 @@
 import os
+import re
+
+from sqlalchemy.engine.url import URL
+
+ORACLE_DRIVER = 'oracle+cx_oracle'
 
 DATABASE_CONFIGS = {
     'Grondslag': {
-        'drivername': 'oracle+cx_oracle',
+        'drivername': ORACLE_DRIVER,
         'username': os.getenv("DBIMBP01_DATABASE_USER", "gob"),
         'password': os.getenv("DBIMBP01_DATABASE_PASSWORD", "insecure"),
         'host': os.getenv("DBIMBP01_DATABASE_HOST", "hostname"),
@@ -10,7 +15,7 @@ DATABASE_CONFIGS = {
         'database': 'DBIMBP01'
     },
     'DGDialog': {
-        'drivername': 'oracle+cx_oracle',
+        'drivername': ORACLE_DRIVER,
         'username': os.getenv("BINBGT01_DATABASE_USER", "gob"),
         'password': os.getenv("BINBGT01_DATABASE_PASSWORD", "insecure"),
         'host': os.getenv("BINBGT01_DATABASE_HOST", "hostname"),
@@ -18,7 +23,7 @@ DATABASE_CONFIGS = {
         'database': 'binbgt11.amsterdam.nl'
     },
     'DIVA': {
-        'drivername': 'oracle+cx_oracle',
+        'drivername': ORACLE_DRIVER,
         'username': os.getenv("DBIGMA01_DATABASE_USER", "gob"),
         'password': os.getenv("DBIGMA01_DATABASE_PASSWORD", "insecure"),
         'host': os.getenv("DBIGMA01_DATABASE_HOST", "hostname"),
@@ -38,3 +43,22 @@ OBJECTSTORE_CONFIGS = {
         "REGION_NAME": 'NL'
     }
 }
+
+
+def get_url(db_config):
+    """Get URL connection
+
+    Get the URL for the given database config
+
+    :param db_config: e.g. DATABASE_CONFIGS['DIVA']
+    :return: url
+    """
+    # Default behaviour is to return the sqlalchemy url result
+    url = URL(**db_config)
+    if db_config["drivername"] == ORACLE_DRIVER:
+        # The Oracle driver can accept a service name instead of a SID
+        service_name_pattern = re.compile("^\w+\.\w+\.\w+$")
+        if service_name_pattern.match(db_config["database"]):
+            # Replace the SID by the service name
+            url = str(url).replace(db_config["database"], '?service_name=' + db_config['database'])
+    return url

--- a/src/gobimport/connector/database.py
+++ b/src/gobimport/connector/database.py
@@ -5,12 +5,9 @@ The following connectors are implemented in this module:
 
 """
 from sqlalchemy import create_engine
-from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import DBAPIError
-
 from gobcore.exceptions import GOBException
-
-from gobimport.connector.config import DATABASE_CONFIGS
+from gobimport.connector.config import DATABASE_CONFIGS, get_url
 
 
 def connect_to_database(source):
@@ -28,7 +25,7 @@ def connect_to_database(source):
 
     user = f"({DB['username']}@{DB['database']})"
     try:
-        engine = create_engine(URL(**DB))
+        engine = create_engine(get_url(DB))
         connection = engine.connect()
 
     except DBAPIError as e:

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -13,11 +13,13 @@ Todo: improve type conversion
 """
 
 import datetime
+import traceback
 
 from gobcore.log import get_logger
 from gobcore.message_broker import publish
 
 from gobimport.converter import convert_data
+from gobimport.injections import inject
 from gobimport.connector import connect_to_database, connect_to_objectstore, connect_to_file
 from gobimport.reader import read_from_database, read_from_objectstore, read_from_file
 from gobimport.validator import Validator
@@ -99,6 +101,9 @@ class ImportClient:
         self.log(level='info',
                  msg=f"Data has been imported from {self.source['name']}.")
 
+    def inject(self):
+        inject(self.source.get("inject"), self._data)
+
     def enrich(self):
         enrich(self.catalogue, self.entity, self._data)
 
@@ -157,10 +162,14 @@ class ImportClient:
         try:
             self.connect()
             self.read()
+            self.inject()
             self.validate()
             self.enrich()
             self.convert()
             self.publish()
         except Exception as e:
-            self.log(level='error',
-                     msg=f'Import failed: {e}')
+            # Print error message, the message that caused the error and a short stacktrace
+            stacktrace = traceback.format_exc(limit=-5)
+            print("Import failed: {e}", stacktrace)
+            # Log the error and a short error description
+            self.log(level='error', msg=f'Import failed: {e}')

--- a/src/gobimport/injections.py
+++ b/src/gobimport/injections.py
@@ -1,0 +1,81 @@
+"""Injections
+
+Conversion logic to populate a source with fixed data
+
+This van be used when importing data from new sources
+The data in the new source can be populated so that it joins the previous source
+
+ToDo: handle data that has states (key consists of multiple items)
+"""
+import json
+
+
+def _apply_injection(row, key, operator, value):
+    """Apply an injection
+
+    :param row: the data row to which the injection should be applied
+    :param key: the key
+    :param operator: the operator to apply
+    :param value: the value to apply
+    :return:
+    """
+    # Process an injection
+    if operator == "=":  # Overwrite value
+        row[key] = value
+    if operator == "+":  # Add to value
+        row[key] += value
+
+
+def inject(inject_spec, data):
+    """Inject data
+
+    Inject data from another source into data
+
+    :param inject_spec: filename of other source specifications
+    :param data: the data to inject into
+    :return: None
+    """
+    if not inject_spec:
+        return
+
+    # {
+    #     "from": "<input file name>",
+    #     "on": "<fieldname of field that relates the two sources>",
+    #     "conversions": {
+    #         "fieldname": "<operator>",
+    #         ...
+    #     }
+    # }
+
+    inject_from = inject_spec["from"]
+    inject_on = inject_spec["on"]
+    conversions = inject_spec["conversions"]
+
+    # [
+    #     {
+    #         "<fieldname of field that relates the two sources>" : "<key value>",
+    #         "<any fieldname>" : "<any value>",
+    #         ...
+    #     }, ...
+    # ]
+    with open(inject_from) as file:
+        injections = json.load(file)
+
+    # Convert injections into dict for fast access
+    injections = {injection[inject_on]: injection for injection in injections}
+
+    # {
+    #     "<key value>": {
+    #         "<any fieldname>" : "<any value>",
+    #     }, ...
+    # }
+
+    for row in data:
+        # Process each row
+        inject_key = row[inject_on]  # e.g. data["code"]
+        inject_spec = injections.get(inject_key)  # e.g. injections["A"]
+        if not inject_spec:
+            continue
+
+        for key, operator in conversions.items():
+            _apply_injection(row=row, key=key, operator=operator, value=inject_spec[key])

--- a/src/test.sh
+++ b/src/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobimport --cov-report html --cov-fail-under=0
+pytest --cov=gobimport --cov-report html --cov-fail-under=40

--- a/src/test.sh
+++ b/src/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobimport --cov-report html --cov-fail-under=40
+pytest --cov=gobimport --cov-report html --cov-fail-under=45

--- a/src/test.sh
+++ b/src/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobimport --cov-report html --cov-fail-under=45
+pytest --cov=gobimport --cov-report html --cov-fail-under=46

--- a/src/tests/test_connector.py
+++ b/src/tests/test_connector.py
@@ -1,0 +1,42 @@
+import unittest
+
+from gobimport.connector.config import get_url, ORACLE_DRIVER
+
+class TestInjections(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_get_url(self):
+        # Leave Oracle SID as it is
+        config = {
+            'drivername': ORACLE_DRIVER,
+            'username': "username",
+            'password': "password",
+            'host': "host",
+            'port': 1234,
+            'database': 'SID'
+        }
+        self.assertEqual(str(get_url(config)), "oracle+cx_oracle://username:password@host:1234/SID")
+
+        # Handle Oracle service name
+        config = {
+            'drivername': ORACLE_DRIVER,
+            'username': "username",
+            'password': "password",
+            'host': "host",
+            'port': 1234,
+            'database': 'x.y.z'
+        }
+        self.assertEqual(str(get_url(config)), "oracle+cx_oracle://username:password@host:1234/?service_name=x.y.z")
+
+        # Handle it only or Oracle
+        config = {
+            'drivername': "driver",
+            'username': "username",
+            'password': "password",
+            'host': "host",
+            'port': 1234,
+            'database': 'x.y.z'
+        }
+        self.assertEqual(str(get_url(config)), "driver://username:password@host:1234/x.y.z")

--- a/src/tests/test_injections.py
+++ b/src/tests/test_injections.py
@@ -109,7 +109,7 @@ class TestInjections(unittest.TestCase):
             {
                 "id": 1,
                 "field1": "0",
-                "field2": 0,
+                "field2": 2,
                 "field3": "x"
             }
         ]
@@ -135,55 +135,9 @@ class TestInjections(unittest.TestCase):
             {
                 "id": 1,
                 "field1": "aap",
-                "field2": 10,
+                "field2": 12,
                 "field3": "x"
             }
         ]
         inject(inject_spec, data)
         self.assertEqual(data, expect)
-
-
-    # def test_validat_data(self):
-    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
-    #     validator.validate()
-    #
-    # def test_duplicate_primary_key(self):
-    #     self.valid_meetbouten.append(self.valid_meetbouten[0])
-    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
-    #
-    #     with self.assertRaises(GOBException):
-    #         validator.validate()
-    #
-    # def test_invalid_data(self):
-    #     validator = Validator(self.mock_import_client, 'meetbouten', self.invalid_meetbouten, 'identificatie')
-    #     validator.validate()
-    #
-    #     # Make sure the statusid has been listed as invalid
-    #     self.assertEqual(validator.collection_qa['num_invalid_status_id'], 1)
-    #
-    # def test_fatal_value(self):
-    #     validator = Validator(self.mock_import_client, 'meetbouten', self.fatal_meetbouten, 'identificatie')
-    #
-    #     with self.assertRaises(GOBException):
-    #         validator.validate()
-    #
-    #     # Make sure the identificatie has been listed as invalid
-    #     self.assertEqual(validator.collection_qa['num_invalid_identificatie'], 1)
-    #
-    # def test_missing_warning_data(self):
-    #     missing_attr_meetbouten = self.valid_meetbouten[0].pop('status_id')
-    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
-    #     validator.validate()
-    #
-    #     # Make sure the publiceerbaar has been listed as invalid
-    #     self.assertEqual(validator.collection_qa['num_invalid_status_id'], 1)
-    #
-    # def test_missing_fatal_data(self):
-    #     missing_attr_meetbouten = self.valid_meetbouten[0].pop('publiceerbaar')
-    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
-    #
-    #     with self.assertRaises(GOBException):
-    #         validator.validate()
-    #
-    #     # Make sure the publiceerbaar has been listed as invalid
-    #     self.assertEqual(validator.collection_qa['num_invalid_publiceerbaar'], 1)

--- a/src/tests/test_injections.py
+++ b/src/tests/test_injections.py
@@ -1,0 +1,189 @@
+import unittest
+import json
+
+from unittest import mock
+
+from gobimport.injections import inject, _apply_injection
+
+class TestInjections(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_no_injections(self):
+        data = []
+        inject(None, data)
+
+        self.assertEqual(data, [])
+
+    @mock.patch('builtins.open')
+    def test_empty_injections(self, mock_open):
+        injections = []
+        mock_open.side_effect = [
+            mock.mock_open(read_data=json.dumps(injections)).return_value,
+        ]
+        inject_spec = {
+            "from": "anyfile",
+            "on": "id",
+            "conversions": {
+                "field1": "=",
+                "field2": "+"
+            }
+        }
+        data = []
+        inject(inject_spec, data)
+        self.assertEqual(data, [])
+
+    @mock.patch('builtins.open')
+    def test_injections_no_data(self, mock_open):
+        injections = [
+            {
+                "id": 1,
+                "field1": "aap",
+                "field2": 10
+            }
+        ]
+        mock_open.side_effect = [
+            mock.mock_open(read_data=json.dumps(injections)).return_value,
+        ]
+        inject_spec = {
+            "from": "anyfile",
+            "on": "id",
+            "conversions": {
+                "field1": "=",
+                "field2": "+"
+            }
+        }
+        data = []
+        inject(inject_spec, data)
+        self.assertEqual(data, [])
+
+    def test_apply_injection(self):
+        row = {}
+        _apply_injection(row, "key", "=", "aap")
+        self.assertEqual(row, {"key": "aap"})
+
+        row = {"key": 1}
+        _apply_injection(row, "key", "+", 1)
+        self.assertEqual(row, {"key": 2})
+
+    @mock.patch('builtins.open')
+    def test_injections_with_data(self, mock_open):
+        injections = [
+            {
+                "id": 1,
+                "field1": "aap",
+                "field2": 10
+            }
+        ]
+        mock_open.side_effect = [
+            mock.mock_open(read_data=json.dumps(injections)).return_value,
+        ]
+        inject_spec = {
+            "from": "anyfile",
+            "on": "id",
+            "conversions": {
+                "field1": "=",
+                "field2": "+"
+            }
+        }
+        data = [
+            {
+                "id": 0,
+                "field1": "0",
+                "field2": 0,
+                "field3": "x"
+            },
+            {
+                "id": 1,
+                "field1": "0",
+                "field2": 0,
+                "field3": "x"
+            },
+            {
+                "id": 2,
+                "field1": "0",
+                "field2": 0,
+                "field3": "x"
+            },
+            {
+                "id": 1,
+                "field1": "0",
+                "field2": 0,
+                "field3": "x"
+            }
+        ]
+        expect = [
+            {
+                "id": 0,
+                "field1": "0",
+                "field2": 0,
+                "field3": "x"
+            },
+            {
+                "id": 1,
+                "field1": "aap",
+                "field2": 10,
+                "field3": "x"
+            },
+            {
+                "id": 2,
+                "field1": "0",
+                "field2": 0,
+                "field3": "x"
+            },
+            {
+                "id": 1,
+                "field1": "aap",
+                "field2": 10,
+                "field3": "x"
+            }
+        ]
+        inject(inject_spec, data)
+        self.assertEqual(data, expect)
+
+
+    # def test_validat_data(self):
+    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
+    #     validator.validate()
+    #
+    # def test_duplicate_primary_key(self):
+    #     self.valid_meetbouten.append(self.valid_meetbouten[0])
+    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
+    #
+    #     with self.assertRaises(GOBException):
+    #         validator.validate()
+    #
+    # def test_invalid_data(self):
+    #     validator = Validator(self.mock_import_client, 'meetbouten', self.invalid_meetbouten, 'identificatie')
+    #     validator.validate()
+    #
+    #     # Make sure the statusid has been listed as invalid
+    #     self.assertEqual(validator.collection_qa['num_invalid_status_id'], 1)
+    #
+    # def test_fatal_value(self):
+    #     validator = Validator(self.mock_import_client, 'meetbouten', self.fatal_meetbouten, 'identificatie')
+    #
+    #     with self.assertRaises(GOBException):
+    #         validator.validate()
+    #
+    #     # Make sure the identificatie has been listed as invalid
+    #     self.assertEqual(validator.collection_qa['num_invalid_identificatie'], 1)
+    #
+    # def test_missing_warning_data(self):
+    #     missing_attr_meetbouten = self.valid_meetbouten[0].pop('status_id')
+    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
+    #     validator.validate()
+    #
+    #     # Make sure the publiceerbaar has been listed as invalid
+    #     self.assertEqual(validator.collection_qa['num_invalid_status_id'], 1)
+    #
+    # def test_missing_fatal_data(self):
+    #     missing_attr_meetbouten = self.valid_meetbouten[0].pop('publiceerbaar')
+    #     validator = Validator(self.mock_import_client, 'meetbouten', self.valid_meetbouten, 'identificatie')
+    #
+    #     with self.assertRaises(GOBException):
+    #         validator.validate()
+    #
+    #     # Make sure the publiceerbaar has been listed as invalid
+    #     self.assertEqual(validator.collection_qa['num_invalid_publiceerbaar'], 1)


### PR DESCRIPTION
Import DGDialog (replaces DIVA)
Inject conversion data from DIVA into DGDialog import
Allow usage of Oracle Service Names, besides SID's