### PR TITLE
Remove entity id from mapping

### DIFF
--- a/src/data/bouwblokken.diva.json
+++ b/src/data/bouwblokken.diva.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "gebieden",
   "entity": "bouwblokken",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "DIVA",

--- a/src/data/buurten.diva.json
+++ b/src/data/buurten.diva.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "gebieden",
   "entity": "buurten",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "DIVA",

--- a/src/data/meetbouten.json
+++ b/src/data/meetbouten.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "meetbouten",
   "entity": "meetbouten",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "Grondslag",

--- a/src/data/metingen.json
+++ b/src/data/metingen.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "meetbouten",
   "entity": "metingen",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "Grondslag",

--- a/src/data/peilmerken.json
+++ b/src/data/peilmerken.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "nap",
   "entity": "peilmerken",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "Grondslag",

--- a/src/data/referentiepunten.json
+++ b/src/data/referentiepunten.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "meetbouten",
   "entity": "referentiepunten",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "Grondslag",

--- a/src/data/rollagen.json
+++ b/src/data/rollagen.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "meetbouten",
   "entity": "rollagen",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "Basisinformatie",

--- a/src/data/stadsdelen.diva.json
+++ b/src/data/stadsdelen.diva.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "gebieden",
   "entity": "stadsdelen",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "DIVA",

--- a/src/data/stadsdelen.json
+++ b/src/data/stadsdelen.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "gebieden",
   "entity": "stadsdelen",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "DGDialog",

--- a/src/data/test/test.json
+++ b/src/data/test/test.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "test_catalogue",
   "entity": "test_entity",
-  "entity_id": "string",
   "source": {
     "type": "file",
     "name": "test",

--- a/src/data/test/test.json
+++ b/src/data/test/test.json
@@ -3,9 +3,10 @@
   "catalogue": "test_catalogue",
   "entity": "test_entity",
   "source": {
-    "type": "file",
     "name": "test",
+    "application": "TEST",
     "entity_id": "string",
+    "type": "file",
     "config": {
       "filename": "test/test.csv",
       "filetype": "CSV",

--- a/src/data/wijken.diva.json
+++ b/src/data/wijken.diva.json
@@ -2,7 +2,6 @@
   "version": "0.1",
   "catalogue": "gebieden",
   "entity": "wijken",
-  "entity_id": "identificatie",
   "source": {
     "name": "AMSBI",
     "application": "DIVA",

--- a/src/gobimport/converter.py
+++ b/src/gobimport/converter.py
@@ -107,8 +107,8 @@ def convert_data(data, dataset):
         source_id_value = row[source_id_field]
         source_id_str_value = str(get_gob_type("GOB.String").from_value(source_id_value))
         if entity_specification.get("has_states", False):
-            # Source id + volgnummer is source id
-            source_id_str_value = f"{source_id_str_value}.{target_entity['volgnummer']}"
+            # Source id + datum_begin_geldigheid is source id
+            source_id_str_value = f"{source_id_str_value}.{target_entity['datum_begin_geldigheid']}"
         target_entity['_source_id'] = source_id_str_value
 
         entities.append(target_entity)

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -41,7 +41,6 @@ class ImportClient:
         self.source_id = self._dataset['source']['entity_id']
         self.catalogue = self._dataset['catalogue']
         self.entity = self._dataset['entity']
-        self.entity_id = self._dataset['entity_id']
 
         # Extra variables for logging
         start_timestamp = int(datetime.datetime.now().replace(microsecond=0).timestamp())
@@ -136,7 +135,6 @@ class ImportClient:
             "source": self._dataset['source']['name'],
             "application": self._dataset['source'].get('application'),
             "depends_on": self._dataset['source'].get('depends_on', {}),
-            "id_column": self._dataset['entity_id'],
             "catalogue": self._dataset['catalogue'],
             "entity": self._dataset['entity'],
             "version": self._dataset['version'],

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -135,7 +135,7 @@ class ImportClient:
             "process_id": self.process_id,
             "source": self._dataset['source']['name'],
             "application": self._dataset['source'].get('application'),
-            "depends_on": self._dataset['source'].get('depends_on'),
+            "depends_on": self._dataset['source'].get('depends_on', {}),
             "id_column": self._dataset['entity_id'],
             "catalogue": self._dataset['catalogue'],
             "entity": self._dataset['entity'],

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ cx-Oracle==7.0.0
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.23c#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.23d#egg=gobcore
 -e git+https://github.com/Amsterdam/objectstore.git@v1.0#egg=objectstore
 jsonschema==2.6.0
 mccabe==0.6.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ cx-Oracle==7.0.0
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.23b#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.23c#egg=gobcore
 -e git+https://github.com/Amsterdam/objectstore.git@v1.0#egg=objectstore
 jsonschema==2.6.0
 mccabe==0.6.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ cx-Oracle==7.0.0
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.23d#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.23e#egg=gobcore
 -e git+https://github.com/Amsterdam/objectstore.git@v1.0#egg=objectstore
 jsonschema==2.6.0
 mccabe==0.6.1


### PR DESCRIPTION
The id of an entity is knowledge of GOB Model, not of an import mapping

Fixed bug in source id; entity id (+ datum begin geldigheid for entities with state)