### PR TITLE
DGDialog depends on DIVA

### DIFF
--- a/src/data/stadsdelen.json
+++ b/src/data/stadsdelen.json
@@ -8,6 +8,9 @@
     "entity_id": "source_id",
     "type": "database",
     "schema": "dgdialog",
+    "depends_on": {
+      "_application": "DIVA"
+    },
     "inject": {
       "from": "data/stadsdelen.conversion.json",
       "on": "code",


### PR DESCRIPTION
Previous DIVA contents should be loaded before
DGDialog can be imported