### PR TITLE
Improve imports

### DIFF
--- a/src/data/bouwblokken.json
+++ b/src/data/bouwblokken.json
@@ -16,7 +16,7 @@
       "on": "code",
       "conversions": {
         "identificatie": "=",
-        "volgnummer": "+"
+        "volgnummer": "+-1"
       }
     },
     "enrich": {
@@ -29,7 +29,7 @@
     "query": [
 "    SELECT s.code                               AS code",
 "    ,      NULL                                 AS identificatie",
-"    ,      q1.volgnummer - 1                    AS volgnummer",
+"    ,      q1.volgnummer                        AS volgnummer",
 "    ,      to_char(s.datum, 'YYYY-MM-DD')       AS datum_begin_geldigheid",
 "    ,      to_char(t.verval, 'YYYY-MM-DD')      AS datum_einde_geldigheid",
 "    ,      t.inwin                              AS registratiedatum",

--- a/src/data/buurten.json
+++ b/src/data/buurten.json
@@ -16,7 +16,7 @@
       "on": "code",
       "conversions": {
         "identificatie": "=",
-        "volgnummer": "+"
+        "volgnummer": "+-1"
       }
     },
     "enrich": {
@@ -30,7 +30,7 @@
 "    SELECT s1.naam                                                AS naam",
 "    ,      s1.sdlcode || s1.wijkcode || s1.brtcode                AS code",
 "    ,      NULL                                                   AS identificatie",
-"    ,      q2.volgnummer - 1                                      AS volgnummer",
+"    ,      q2.volgnummer                                          AS volgnummer",
 "    ,      to_char(q2.ingsdatum, 'YYYY-MM-DD')                    AS datum_begin_geldigheid",
 "    ,      to_char(nvl(q2.einddatum, q3.ingsdatum), 'YYYY-MM-DD') AS datum_einde_geldigheid",
 "    ,      to_char(s1.docdatum, 'YYYY-MM-DD')                     AS documentdatum",

--- a/src/data/ggpgebieden.json
+++ b/src/data/ggpgebieden.json
@@ -29,10 +29,10 @@
       "source_mapping": "_IDENTIFICATIE"
     },
     "volgnummer": {
-      "source_mapping": "_VOLGNUMMER"
+      "source_mapping": "volgnummer"
     },
     "registratiedatum": {
-      "source_mapping": "_REGISTRATIEDATUM"
+      "source_mapping": "registratiedatum"
     },
     "naam": {
       "source_mapping": "GGP_NAAM"

--- a/src/data/ggwgebieden.json
+++ b/src/data/ggwgebieden.json
@@ -29,10 +29,10 @@
       "source_mapping": "_IDENTIFICATIE"
     },
     "volgnummer": {
-      "source_mapping": "_VOLGNUMMER"
+      "source_mapping": "volgnummer"
     },
     "registratiedatum": {
-      "source_mapping": "_REGISTRATIEDATUM"
+      "source_mapping": "registratiedatum"
     },
     "naam": {
       "source_mapping": "GGW_NAAM"

--- a/src/data/stadsdelen.json
+++ b/src/data/stadsdelen.json
@@ -16,13 +16,13 @@
       "on": "code",
       "conversions": {
         "identificatie": "=",
-        "volgnummer": "+"
+        "volgnummer": "+-1"
       }
     },
     "query": [
 "    SELECT s1.naam                                                AS naam",
 "    ,      s1.sdlcode                                             AS code",
-"    ,      q2.volgnummer - 1                                      AS volgnummer",
+"    ,      q2.volgnummer                                          AS volgnummer",
 "    ,      to_char(q2.ingsdatum, 'YYYY-MM-DD')                    AS datum_begin_geldigheid",
 "    ,      to_char(nvl(q2.einddatum, q3.ingsdatum), 'YYYY-MM-DD') AS datum_einde_geldigheid",
 "    ,      to_char(s1.docdatum, 'YYYY-MM-DD')                     AS documentdatum",

--- a/src/data/wijken.json
+++ b/src/data/wijken.json
@@ -16,13 +16,13 @@
       "on": "code",
       "conversions": {
         "identificatie": "=",
-        "volgnummer": "+"
+        "volgnummer": "+-1"
       }
     },
     "query": [
 "    SELECT s1.naam                                                AS naam",
 "    ,      s1.sdlcode || s1.wijkcode                              AS code",
-"    ,      q2.volgnummer -1                                       AS volgnummer",
+"    ,      q2.volgnummer                                          AS volgnummer",
 "    ,      to_char(q2.ingsdatum, 'YYYY-MM-DD')                    AS datum_begin_geldigheid",
 "    ,      to_char(nvl(q2.einddatum, q3.ingsdatum), 'YYYY-MM-DD') AS datum_einde_geldigheid",
 "    ,      to_char(s1.docdatum, 'YYYY-MM-DD')                     AS documentdatum",

--- a/src/gobimport/enricher/gebieden.py
+++ b/src/gobimport/enricher/gebieden.py
@@ -63,8 +63,8 @@ def enrich_ggw_ggp_gebieden(entities, prefix):
     for entity in entities:
         entity["BUURTEN"] = entity["BUURTEN"].split(", ")
         entity["_IDENTIFICATIE"] = None
-        entity["_REGISTRATIEDATUM"] = entity["_file_info"]["last_modified"]
-        entity["_VOLGNUMMER"] = _volgnummer_from_date(entity["_REGISTRATIEDATUM"], "%Y-%m-%dT%H:%M:%S.%f")
+        entity["registratiedatum"] = entity["_file_info"]["last_modified"]
+        entity["volgnummer"] = _volgnummer_from_date(entity["registratiedatum"], "%Y-%m-%dT%H:%M:%S.%f")
         for date in [f"{prefix}_{date}" for date in ["BEGINDATUM", "EINDDATUM", "DOCUMENTDATUM"]]:
             if entity[date] is not None:
                 entity[date] = str(entity[date])[:10]   # len "YYYY-MM-DD" = 10

--- a/src/gobimport/entity_validator/gebieden.py
+++ b/src/gobimport/entity_validator/gebieden.py
@@ -8,7 +8,7 @@ import datetime
 from gobcore.logging.logger import logger
 
 
-def _validate_bouwblokken(entities):
+def _validate_bouwblokken(entities, source_id):
     """
     Validate bouwblokken
 
@@ -24,12 +24,13 @@ def _validate_bouwblokken(entities):
     for entity in entities:
         # begin_geldigheid can not be in the future
         # to_db is used to work around the typesystem: https://github.com/Amsterdam/GOB-Core/issues/127
+        identificatie = str(entity[source_id])
         if entity['begin_geldigheid'].to_db > datetime.datetime.utcnow():
             msg = "begin_geldigheid can not be in the future"
             extra_data = {
                 'id': msg,
                 'data': {
-                    'identificatie': entity['identificatie'],
+                    'identificatie': identificatie,
                     'begin_geldigheid': entity['begin_geldigheid'],
                 }
             }
@@ -39,7 +40,7 @@ def _validate_bouwblokken(entities):
     return validated
 
 
-def _validate_buurten(entities):
+def _validate_buurten(entities, source_id):
     """
     Validate buurten
 
@@ -55,6 +56,7 @@ def _validate_buurten(entities):
     for entity in entities:
         # get eind_geldigheid or use current date
         # to_db is used to work around the typesystem: https://github.com/Amsterdam/GOB-Core/issues/127
+        identificatie = str(entity[source_id])
         eind_geldigheid = entity['eind_geldigheid'].to_db if entity['eind_geldigheid'].to_db \
             else datetime.datetime.utcnow()
         documentdatum = entity['documentdatum'].to_db
@@ -65,7 +67,7 @@ def _validate_buurten(entities):
             extra_data = {
                 'id': msg,
                 'data': {
-                    'identificatie': entity['identificatie'],
+                    'identificatie': identificatie,
                     'documentdatum': entity['documentdatum'],
                     'eind_geldigheid': entity['eind_geldigheid'],
                 }

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -124,7 +124,12 @@ class ImportClient:
 
     def entity_validate(self):
         logger.info("Validate Entity")
-        entity_validate(self.catalogue, self.entity, self._gob_data)
+        # Find the functional source id
+        # This is the functional field that is mapped onto the source_id
+        # or _source_id if no mapping exists
+        ids = [key for key, value in self._dataset["gob_mapping"].items() if value["source_mapping"] == self.source_id]
+        func_source_id = ids[0] if ids else "_source_id"
+        entity_validate(self.catalogue, self.entity, self._gob_data, func_source_id)
 
     def publish(self):
         """The result of the import needs to be published.

--- a/src/gobimport/injections.py
+++ b/src/gobimport/injections.py
@@ -22,8 +22,10 @@ def _apply_injection(row, key, operator, value):
     # Process an injection
     if operator == "=":  # Overwrite value
         row[key] = value
-    if operator == "+":  # Add to value
+    elif operator == "+":  # Add to value
         row[key] += value
+    elif operator == "+-1":  # Add to value
+        row[key] += value - 1
 
 
 def inject(inject_spec, data):

--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -183,7 +183,7 @@ ENTITY_CHECKS = {
         ],
     },
     "ggpgebieden": {
-        "naam": [
+        "GGP_NAAM": [
             {
                 "pattern": ".+",
                 "msg": "naam should be filled",

--- a/src/tests/enricher/test_enrich_gebieden.py
+++ b/src/tests/enricher/test_enrich_gebieden.py
@@ -159,8 +159,8 @@ class TestGGWPEnricher(unittest.TestCase):
         self.assertEqual(ggwgebieden, [
             {
                 "_IDENTIFICATIE": None,
-                "_REGISTRATIEDATUM": "2020-01-20T12:30:30.12345",
-                "_VOLGNUMMER": self.volgnummer("2020-01-20T12:30:30.12345"),
+                "registratiedatum": "2020-01-20T12:30:30.12345",
+                "volgnummer": self.volgnummer("2020-01-20T12:30:30.12345"),
                 "GGW_BEGINDATUM": "YYYY-MM-DD",
                 "GGW_EINDDATUM": "YYYY-MM-DD",
                 "GGW_DOCUMENTDATUM": "YYYY-MM-DD",
@@ -185,8 +185,8 @@ class TestGGWPEnricher(unittest.TestCase):
         self.assertEqual(ggpgebieden, [
             {
                 "_IDENTIFICATIE": None,
-                "_REGISTRATIEDATUM": "2020-01-20T12:30:30.12345",
-                "_VOLGNUMMER": self.volgnummer("2020-01-20T12:30:30.12345"),
+                "registratiedatum": "2020-01-20T12:30:30.12345",
+                "volgnummer": self.volgnummer("2020-01-20T12:30:30.12345"),
                 "GGP_BEGINDATUM": "YYYY-MM-DD",
                 "GGP_EINDDATUM": "YYYY-MM-DD",
                 "GGP_DOCUMENTDATUM": None,

--- a/src/tests/entity_validator/test_enrich_gebieden.py
+++ b/src/tests/entity_validator/test_enrich_gebieden.py
@@ -18,7 +18,7 @@ class TestEntityValidator(unittest.TestCase):
                 'eind_geldigheid': GOB.Date.from_value(None),
             }
         ]
-        self.assertTrue(_validate_bouwblokken(self.entities))
+        self.assertTrue(_validate_bouwblokken(self.entities, "identificatie"))
 
     @patch("gobimport.entity_validator.gebieden.logger", MagicMock())
     def test_validate_bouwblokken_invalid(self):
@@ -29,7 +29,7 @@ class TestEntityValidator(unittest.TestCase):
                 'eind_geldigheid': GOB.Date.from_value(None),
             }
         ]
-        self.assertFalse(_validate_bouwblokken(self.entities))
+        self.assertFalse(_validate_bouwblokken(self.entities, "identificatie"))
 
     def test_validate_buurten_valid(self):
         self.entities = [
@@ -39,7 +39,7 @@ class TestEntityValidator(unittest.TestCase):
                 'eind_geldigheid': GOB.Date.from_value('2019-01-01'),
             }
         ]
-        self.assertTrue(_validate_buurten(self.entities))
+        self.assertTrue(_validate_buurten(self.entities, "identificatie"))
 
     @patch("gobimport.entity_validator.gebieden.logger")
     def test_validate_buurten_invalid(self, mock_logger):
@@ -53,7 +53,7 @@ class TestEntityValidator(unittest.TestCase):
         ]
 
         # This test should only call log with a warning statement and return True
-        self.assertTrue(_validate_buurten(self.entities))
+        self.assertTrue(_validate_buurten(self.entities, "identificatie"))
         mock_logger.warning.assert_called_with(
             "documentdatum can not be after eind_geldigheid",
             {

--- a/src/tests/entity_validator/test_entity_validator.py
+++ b/src/tests/entity_validator/test_entity_validator.py
@@ -20,7 +20,7 @@ class TestEntityValidator(unittest.TestCase):
     def test_entity_validate_without_state(self, mock_validate_entity_state, mock_model):
         mock_model.return_value = self.mock_model
         self.mock_model.has_states.return_value = False
-        entity_validate('catalogue', 'collection', self.entities)
+        entity_validate('catalogue', 'collection', self.entities, "identificatie")
 
         # Assert _validate_entity_state not called for collections without state
         mock_validate_entity_state.assert_not_called()
@@ -30,7 +30,7 @@ class TestEntityValidator(unittest.TestCase):
     def test_entity_validate_with_state(self, mock_validate_entity_state, mock_model):
         mock_model.return_value = self.mock_model
         self.mock_model.has_states.return_value = True
-        entity_validate('catalogue', 'collection', self.entities)
+        entity_validate('catalogue', 'collection', self.entities, "identificatie")
 
         # Assert _validate_entity_state called for collections with state
         mock_validate_entity_state.assert_called_once()
@@ -44,7 +44,7 @@ class TestEntityValidator(unittest.TestCase):
 
         # Assert a GOBException was raised when _validate_entity_state fails
         with self.assertRaises(GOBException):
-            entity_validate('catalogue', 'buurten', self.entities)
+            entity_validate('catalogue', 'buurten', self.entities, "identificatie")
 
     def test_validate_entity_state_valid(self):
         self.entities = [
@@ -56,7 +56,7 @@ class TestEntityValidator(unittest.TestCase):
             }
         ]
 
-        self.assertTrue(_validate_entity_state(self.entities))
+        self.assertTrue(_validate_entity_state(self.entities, "identificatie"))
 
     def test_validate_entity_state_invalid_begin_geldigheid(self):
         self.entities = [
@@ -68,8 +68,8 @@ class TestEntityValidator(unittest.TestCase):
             }
         ]
 
-        # Assert false returned and log to be called
-        self.assertFalse(_validate_entity_state(self.entities))
+        # invalid begin geldigheid is not an error but a warning
+        self.assertTrue(_validate_entity_state(self.entities, "identificatie"))
 
     def test_validate_entity_state_invalid_volgnummer(self):
         self.entities = [
@@ -82,7 +82,7 @@ class TestEntityValidator(unittest.TestCase):
         ]
 
         # Assert false returned and log to be called
-        self.assertFalse(_validate_entity_state(self.entities))
+        self.assertFalse(_validate_entity_state(self.entities, "identificatie"))
 
     def test_validate_entity_state_duplicate_volgnummer(self):
         self.entities = [
@@ -101,4 +101,4 @@ class TestEntityValidator(unittest.TestCase):
         ]
 
         # Assert false returned and log to be called
-        self.assertFalse(_validate_entity_state(self.entities))
+        self.assertFalse(_validate_entity_state(self.entities, "identificatie"))


### PR DESCRIPTION
Add a +-1 operator to let volgnummers start at 1 for new entities

Set volgnummer and registratiedatum for GGW/GGP imports

Enable bouwblokken/buurten validations

Derive identification from import specification