### PR TITLE
Limit verblijfsobjecten

### DIFF
--- a/src/data/verblijfsobjecten.json
+++ b/src/data/verblijfsobjecten.json
@@ -162,7 +162,7 @@
 "                     AND    vg.gebruiksdoel_id = 4",
 "                     AND    q1.min_gebruiksdoel != 1) q7  ON v.verblijfseenheid_id = q7.verblijfsobject_id",
 "                                                         AND v.verblijfseenheidvolgnummer = q7.verblijfsobjectvolgnummer",
-"    WHERE    v.indauthentiek = 'J'"
+"    WHERE    v.indauthentiek = 'J' AND v.modification IS NULL"
     ]
   },
   "gob_mapping": {


### PR DESCRIPTION
Only import actual objects

This allows for an import of verblijfsobjecten in the acceptance environment