### PR TITLE
Remove volgnummer from ligt_in_panden

### DIFF
--- a/src/data/verblijfsobjecten.json
+++ b/src/data/verblijfsobjecten.json
@@ -108,7 +108,7 @@
 "    -- selecteren pand(en)",
 "    LEFT OUTER JOIN (SELECT q.verblijfseenheid_id",
 "                     ,      q.verblijfseenheidvolgnummer",
-"                     ,      listagg(q.gebouwnummer || '|' ||q.gebouwvolgnummer, ';') WITHIN GROUP (ORDER BY q.verblijfseenheid_id, q.verblijfseenheidvolgnummer) AS pandidentificatie",
+"                     ,      listagg(q.gebouwnummer, ';') WITHIN GROUP (ORDER BY q.verblijfseenheid_id, q.verblijfseenheidvolgnummer) AS pandidentificatie",
 "                     FROM  (SELECT vg.verblijfseenheid_id",
 "                            ,      vg.verblijfseenheidvolgnummer",
 "                            ,      g.gebouw_id",


### PR DESCRIPTION
Bronwaarde was receiving both the identificatie and volgnummer for the ligt_in_panden relation. Removing the volgnummer will allow the relation to be made