### PR TITLE
Use a literal value for gemeentes

### DIFF
--- a/src/data/brk.gemeentes.json
+++ b/src/data/brk.gemeentes.json
@@ -18,6 +18,10 @@
     },
     "geometrie": {
       "source_mapping": "geometry"
+    },
+    "begin_geldigheid": {
+      "source_mapping": "=2019-01-01 00:00:00",
+      "format": "%Y-%m-%d %H:%M:%S"
     }
   }
 }


### PR DESCRIPTION
We’re currently deciding how we should handle the lack of states for gemeentes, as a temporary solution a literal start date was added