### PR TITLE
Clean references for bronwaarde and broninfo

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.8.5#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.8.5b#egg=gobcore
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5

--- a/src/tests/test_converter.py
+++ b/src/tests/test_converter.py
@@ -3,7 +3,9 @@ from unittest import mock
 
 from decimal import Decimal
 from gobcore.model import GOBModel
-from gobimport.converter import _apply_filters, _extract_references, _is_object_reference, Converter, _json_safe_value
+from gobimport.converter import _apply_filters, _extract_references, _is_object_reference, _split_object_reference, \
+                                Converter, _json_safe_value, _get_value, _clean_references
+from gobcore.exceptions import GOBException
 from tests.fixtures import random_string
 
 
@@ -42,6 +44,34 @@ class TestConverter(unittest.TestCase):
 
         for testcase, result in testcases:
             self.assertEqual(result, _is_object_reference(testcase), f"Case {testcase} should return {result}")
+
+    def test_split_object_reference(self):
+        valid_testcase = (
+            ("this.andthat", ("this", "andthat")),
+        )
+
+        for testcase, result in valid_testcase:
+            self.assertEqual(result, _split_object_reference(testcase), f"Case {testcase} should return {result}")
+
+        invalid_testcases = [
+            "this",
+            "this.that.andthat",
+            ".",
+        ]
+
+        with self.assertRaises(GOBException):
+            for testcase in invalid_testcases:
+                _split_object_reference(testcase)
+
+    def test_get_value(self):
+        valid_testcase = (
+            ({'row':{'field': 'value'}, 'field':'field'}, 'value'),
+            ({'row':{}, 'field':'=field'}, 'field'),
+            ({'row':{'field': {'nested_field': 'value'}}, 'field':'field.nested_field'}, {'nested_field': 'value'}),
+        )
+
+        for testcase, result in valid_testcase:
+            self.assertEqual(result, _get_value(testcase['row'], testcase['field']), f"Case {testcase} should return {result}")
 
     def test_extract_references_bronwaarde_object_ref(self):
         row = {
@@ -115,6 +145,60 @@ class TestConverter(unittest.TestCase):
             "another_col": row["ref_col"][1]["another_col"],
         }]
         self.assertEqual(expected_result, result)
+
+    def test_clean_reference(self):
+        reference = {
+            'bronwaarde': random_string(),
+            'other_col': random_string(),
+        }
+
+        expected_result = {
+            'bronwaarde': reference['bronwaarde'],
+            'broninfo': {
+                'other_col': reference['other_col'],
+            }
+        }
+        result = _clean_references(reference)
+        self.assertEqual(expected_result, result)
+
+
+    def test_clean_reference_without_other_values(self):
+        reference = {
+            'bronwaarde': random_string(),
+        }
+
+        expected_result = {
+            'bronwaarde': reference['bronwaarde'],
+        }
+        result = _clean_references(reference)
+        self.assertEqual(expected_result, result)
+
+
+    def test_clean_manyreference(self):
+        reference = [{
+            'bronwaarde': random_string(),
+            'other_col': random_string(),
+        },
+        {
+            'bronwaarde': random_string(),
+            'other_col': random_string(),
+        }]
+
+        expected_result = [{
+            'bronwaarde': reference[0]['bronwaarde'],
+            'broninfo': {
+                'other_col': reference[0]['other_col'],
+            }
+        },
+        {
+            'bronwaarde': reference[1]['bronwaarde'],
+            'broninfo': {
+                'other_col': reference[1]['other_col'],
+            }
+        }]
+        result = _clean_references(reference)
+        self.assertEqual(expected_result, result)
+
 
     @mock.patch("gobimport.converter._json_safe_value", lambda x: 'safe ' + x)
     @mock.patch("gobimport.converter._get_value", lambda x, y: x[y])


### PR DESCRIPTION
If a reference receives a dictionary, all values other than the specified bronwaarde will be moved into broninfo