### PR TITLE
Use volgnummer from column on GGW GGP

### DIFF
--- a/src/data/ggpgebieden.json
+++ b/src/data/ggpgebieden.json
@@ -32,7 +32,7 @@
       "source_mapping": "_IDENTIFICATIE"
     },
     "volgnummer": {
-      "source_mapping": "volgnummer"
+      "source_mapping": "VOLGNUMMER"
     },
     "registratiedatum": {
       "source_mapping": "registratiedatum"

--- a/src/data/ggwgebieden.json
+++ b/src/data/ggwgebieden.json
@@ -32,7 +32,7 @@
       "source_mapping": "_IDENTIFICATIE"
     },
     "volgnummer": {
-      "source_mapping": "volgnummer"
+      "source_mapping": "VOLGNUMMER"
     },
     "registratiedatum": {
       "source_mapping": "registratiedatum"

--- a/src/gobimport/enricher/gebieden.py
+++ b/src/gobimport/enricher/gebieden.py
@@ -2,7 +2,6 @@
 Gebieden enrichment
 
 """
-from datetime import datetime
 import requests
 
 from gobcore.logging.logger import logger
@@ -111,20 +110,9 @@ class GebiedenEnricher(Enricher):
         entity["BUURTEN"] = entity["BUURTEN"].split(", ")
         entity["_IDENTIFICATIE"] = None
         entity["registratiedatum"] = entity["_file_info"]["last_modified"]
-        entity["volgnummer"] = _volgnummer_from_date(entity["registratiedatum"], "%Y-%m-%dT%H:%M:%S.%f")
         for date in [f"{prefix}_{date}" for date in ["BEGINDATUM", "EINDDATUM", "DOCUMENTDATUM"]]:
             if entity[date] is not None:
                 entity[date] = str(entity[date])[:10]   # len "YYYY-MM-DD" = 10
-
-
-def _volgnummer_from_date(date_str, date_format):
-    """Generate a volgnummer from a date
-
-    :param date_str: date string to derive volgnummer from
-    :param date_format: format of date string
-    :return: a volgnummer that is higher for recent dates and lower for oldest dates
-    """
-    return int(datetime.strptime(date_str, date_format).timestamp())
 
 
 def _match_cbs_features(entity, features):

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -78,7 +78,7 @@ class ImportClient:
 
         self.injector = Injector(self.source.get("inject"))
         self.enricher = Enricher(self.source_app, self.catalogue, self.entity)
-        self.validator = Validator(self.source_app, self.entity, self.source_id)
+        self.validator = Validator(self.source_app, self.entity, self.source_id, self.dataset)
         self.converter = Converter(self.catalogue, self.entity, self.dataset)
 
     def get_result_msg(self):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.9.3#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.9.6#egg=gobcore
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5

--- a/src/test.sh
+++ b/src/test.sh
@@ -13,4 +13,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobimport --cov-report html --cov-fail-under=85
+pytest --cov=gobimport --cov-report html --cov-fail-under=86

--- a/src/tests/enricher/test_enrich_gebieden.py
+++ b/src/tests/enricher/test_enrich_gebieden.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import mock
 
 from gobimport.enricher.gebieden import GebiedenEnricher, CBS_BUURTEN_API, CBS_WIJKEN_API
-from gobimport.enricher.gebieden import _volgnummer_from_date
+
 
 class MockResponse:
 
@@ -146,9 +146,6 @@ class TestGGWPEnricher(unittest.TestCase):
             }
         ]
 
-    def volgnummer(self, date_str):
-        return _volgnummer_from_date(date_str, "%Y-%m-%dT%H:%M:%S.%f")
-
     def test_enrich_ggwgebieden(self):
         ggwgebieden = [
             {
@@ -168,7 +165,6 @@ class TestGGWPEnricher(unittest.TestCase):
             {
                 "_IDENTIFICATIE": None,
                 "registratiedatum": "2020-01-20T12:30:30.12345",
-                "volgnummer": self.volgnummer("2020-01-20T12:30:30.12345"),
                 "GGW_BEGINDATUM": "YYYY-MM-DD",
                 "GGW_EINDDATUM": "YYYY-MM-DD",
                 "GGW_DOCUMENTDATUM": "YYYY-MM-DD",
@@ -196,7 +192,6 @@ class TestGGWPEnricher(unittest.TestCase):
             {
                 "_IDENTIFICATIE": None,
                 "registratiedatum": "2020-01-20T12:30:30.12345",
-                "volgnummer": self.volgnummer("2020-01-20T12:30:30.12345"),
                 "GGP_BEGINDATUM": "YYYY-MM-DD",
                 "GGP_EINDDATUM": "YYYY-MM-DD",
                 "GGP_DOCUMENTDATUM": None,

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -17,6 +17,11 @@ def get_valid_meetbouten():
         'publiceerbaar': random.choice(['1', '0']),
     }]
 
+def get_valid_entity_with_state():
+    return [{
+        'identificatie': random_string(8, ['0','1','2','3','4','5','6','7','8','9']),
+        'volgnummer': random_string(1, ['0','1','2','3','4','5','6','7','8','9'])
+    }]
 
 def get_fatal_meetbouten():
     return [{

--- a/src/tests/test_validator.py
+++ b/src/tests/test_validator.py
@@ -23,27 +23,95 @@ class TestValidator(unittest.TestCase):
         self.nopubliceerbaar_meetbouten = fixtures.get_nopubliceerbaar_meetbouten()
         self.nullpubliceerbaar_meetbouten = fixtures.get_nullpubliceerbaar_meetbouten()
 
+        self.mock_input_spec = {
+            'catalogue': 'meetbouten',
+            'entity': 'meetbouten',
+            'source': {
+                'entity_id': 'identificatie'
+            }
+        }
+
         self.mock_import_client = mock.MagicMock(spec=ImportClient)
         self.mock_import_client.source = {
             'name': 'test'
         }
 
     def test_validat_data(self):
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
         for entity in self.valid_meetbouten:
             validator.validate(entity)
 
     def test_duplicate_primary_key(self):
         self.valid_meetbouten.append(self.valid_meetbouten[0])
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
 
         with self.assertRaises(GOBException):
             for entity in self.valid_meetbouten:
                 validator.validate(entity)
             validator.result()
 
+    def test_valid_primary_key_with_states(self):
+        mock_input_spec = {
+            'catalogue': 'bag',
+            'entity': 'woonplaatsen',
+            'source': {
+                'entity_id': 'identificatie'
+            }
+        }
+
+        valid_entity = fixtures.get_valid_entity_with_state()
+        validator = Validator('source_app', 'woonplaatsen', 'identificatie', mock_input_spec)
+
+        for entity in valid_entity:
+            validator.validate(entity)
+        validator.result()
+
+    def test_valid_primary_key_with_states_other_seqnr(self):
+        mock_input_spec = {
+            'catalogue': 'bag',
+            'entity': 'woonplaatsen',
+            'source': {
+                'entity_id': 'identificatie'
+            },
+            'gob_mapping': {
+                'volgnummer': {
+                    'source_mapping': 'nummervolg'
+                }
+            }
+        }
+
+        valid_entity = [{'identificatie': '1234', 'nummervolg': '1'}]
+        validator = Validator('source_app', 'woonplaatsen', 'identificatie', mock_input_spec)
+
+        for entity in valid_entity:
+            validator.validate(entity)
+        validator.result()
+
+    def test_duplicate_primary_key_with_states_other_seqnr(self):
+        mock_input_spec = {
+            'catalogue': 'bag',
+            'entity': 'woonplaatsen',
+            'source': {
+                'entity_id': 'identificatie'
+            },
+            'gob_mapping': {
+                'volgnummer': {
+                    'source_mapping': 'nummervolg'
+                }
+            }
+        }
+
+        valid_entity = [{'identificatie': '1234', 'nummervolg': '1'}]
+        valid_entity.append(valid_entity[0])
+        validator = Validator('source_app', 'woonplaatsen', 'identificatie', mock_input_spec)
+
+        with self.assertRaises(GOBException):
+            for entity in valid_entity:
+                validator.validate(entity)
+            validator.result()
+
     def test_invalid_data(self):
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
         for entity in self.invalid_meetbouten:
             validator.validate(entity)
 
@@ -51,7 +119,7 @@ class TestValidator(unittest.TestCase):
         self.assertEqual(validator.collection_qa['num_invalid_status_id'], 1)
 
     def test_fatal_value(self):
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
 
         with self.assertRaises(GOBException):
             for entity in self.fatal_meetbouten:
@@ -63,7 +131,7 @@ class TestValidator(unittest.TestCase):
 
     def test_missing_warning_data(self):
         missing_attr_meetbouten = self.valid_meetbouten[0].pop('status_id')
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
 
         for entity in self.valid_meetbouten:
             validator.validate(entity)
@@ -73,7 +141,7 @@ class TestValidator(unittest.TestCase):
 
     def test_missing_fatal_data(self):
         missing_attr_meetbouten = self.valid_meetbouten[0].pop('publiceerbaar')
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
 
         for entity in self.valid_meetbouten:
             validator.validate(entity)
@@ -82,7 +150,7 @@ class TestValidator(unittest.TestCase):
         self.assertEqual(validator.collection_qa['num_invalid_publiceerbaar'], 1)   # Warning
 
     def test_nopubliceerbaar(self):
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
 
         for entity in self.nopubliceerbaar_meetbouten:
             validator.validate(entity)
@@ -91,7 +159,7 @@ class TestValidator(unittest.TestCase):
         self.assertEqual(validator.collection_qa['num_invalid_publiceerbaar'], 1)   # Warning
 
     def test_nullpubliceerbaar(self):
-        validator = Validator('source_app', 'meetbouten', 'identificatie')
+        validator = Validator('source_app', 'meetbouten', 'identificatie', self.mock_input_spec)
 
         for entity in self.nullpubliceerbaar_meetbouten:
             validator.validate(entity)


### PR DESCRIPTION
Changing volgnummer on GGW/GGP resulted in some findings on entity validation and convertion. The code assumed an entity with states always has a column named ‘volgnummer’ while this should be configurable in the import mapping. Fox example the column in the GGW/GGP files was named ‘VOLGNUMMER’. Changes were made to core and validator to make this possible.