### PR TITLE
Partial upload

### DIFF
--- a/src/data/metingen.json
+++ b/src/data/metingen.json
@@ -9,17 +9,19 @@
     "type": "oracle",
     "schema": "grondslag",
     "query": [
-"    SELECT m.id                                AS identificatie",
-"    ,      h1.nummer                           AS hoort_bij_meetbout",
-"    ,      to_char(m.inwindatum, 'YYYY-MM-DD') AS datum",
-"    ,      m.wijze_inwinning                   AS wijze_van_inwinnen_id",
-"    ,      i.omschrijving                      AS wijze_van_inwinnen",
-"    ,      m.hoogte                            AS hoogte_tov_nap",
-"    ,      q.nummer                            AS refereert_aan_refpunt",
-"    ,      b.omschrijving                      AS is_gemeten_door_onderneming",
-"    ,      h1.orde                             AS publiceerbaar -- publiceren ja (1) of nee (0)",
-"    ,      m.id                                AS source_id",
+"    SELECT * FROM (",
+"    SELECT m.id                                            AS identificatie",
+"    ,      h1.nummer                                       AS hoort_bij_meetbout",
+"    ,      to_char(m.inwindatum, 'YYYY-MM-DD')             AS datum",
+"    ,      m.wijze_inwinning                               AS wijze_van_inwinnen_id",
+"    ,      i.omschrijving                                  AS wijze_van_inwinnen",
+"    ,      m.hoogte                                        AS hoogte_tov_nap",
+"    ,      q.nummer                                        AS refereert_aan_refpunt",
+"    ,      b.omschrijving                                  AS is_gemeten_door_onderneming",
+"    ,      h1.orde                                         AS publiceerbaar -- publiceren ja (1) of nee (0)",
+"    ,      m.id                                            AS source_id",
 "    ,      to_char(h1.vervaldatum,'YYYY-MM-DD HH24:MI:SS') AS expirationdate",
+"    ,      m.inwindatum                                    AS modification_date",
 "    FROM              grondslag.grs_hoogtepunten         h1",
 "    JOIN              grondslag.grs_metingen_herz        m  ON h1.id = m.hoo_id",
 "    LEFT OUTER JOIN  (SELECT r.met_id",
@@ -32,7 +34,11 @@
 "    LEFT OUTER JOIN   grondslag.grs_bronnen              b  ON m.bro_id = b.id",
 "    WHERE (h1.typ_nummer = 7                   --deformatiebout",
 "    OR    (h1.typ_nummer = 8 AND h1.orde = 1)) --referentiebout",
-"    ORDER BY datum"
+"    ORDER BY datum",
+"    )"
+    ],
+    "random": [
+"    WHERE mod(hoort_bij_meetbout, 10) = mod(extract(DAY FROM sysdate), 10)"
     ]
   },
   "gob_mapping": {

--- a/src/data/metingen.json
+++ b/src/data/metingen.json
@@ -10,18 +10,17 @@
     "schema": "grondslag",
     "query": [
 "    SELECT * FROM (",
-"    SELECT m.id                                            AS identificatie",
-"    ,      h1.nummer                                       AS hoort_bij_meetbout",
-"    ,      to_char(m.inwindatum, 'YYYY-MM-DD')             AS datum",
-"    ,      m.wijze_inwinning                               AS wijze_van_inwinnen_id",
-"    ,      i.omschrijving                                  AS wijze_van_inwinnen",
-"    ,      m.hoogte                                        AS hoogte_tov_nap",
-"    ,      q.nummer                                        AS refereert_aan_refpunt",
-"    ,      b.omschrijving                                  AS is_gemeten_door_onderneming",
-"    ,      h1.orde                                         AS publiceerbaar -- publiceren ja (1) of nee (0)",
-"    ,      m.id                                            AS source_id",
+"    SELECT m.id                                AS identificatie",
+"    ,      h1.nummer                           AS hoort_bij_meetbout",
+"    ,      to_char(m.inwindatum, 'YYYY-MM-DD') AS datum",
+"    ,      m.wijze_inwinning                   AS wijze_van_inwinnen_id",
+"    ,      i.omschrijving                      AS wijze_van_inwinnen",
+"    ,      m.hoogte                            AS hoogte_tov_nap",
+"    ,      q.nummer                            AS refereert_aan_refpunt",
+"    ,      b.omschrijving                      AS is_gemeten_door_onderneming",
+"    ,      h1.orde                             AS publiceerbaar -- publiceren ja (1) of nee (0)",
+"    ,      m.id                                AS source_id",
 "    ,      to_char(h1.vervaldatum,'YYYY-MM-DD HH24:MI:SS') AS expirationdate",
-"    ,      m.inwindatum                                    AS modification_date",
 "    FROM              grondslag.grs_hoogtepunten         h1",
 "    JOIN              grondslag.grs_metingen_herz        m  ON h1.id = m.hoo_id",
 "    LEFT OUTER JOIN  (SELECT r.met_id",
@@ -37,7 +36,7 @@
 "    ORDER BY datum",
 "    )"
     ],
-    "random": [
+    "some_day": [
 "    WHERE mod(hoort_bij_meetbout, 10) = mod(extract(DAY FROM sysdate), 10)"
     ]
   },

--- a/src/data/verblijfsobjecten.json
+++ b/src/data/verblijfsobjecten.json
@@ -187,11 +187,8 @@
 "                                                         AND v.verblijfseenheidvolgnummer = q7.verblijfsobjectvolgnummer",
 "    WHERE    v.indauthentiek = 'J'"
     ],
-    "last5days": [
+    "recent": [
 "        AND (v.creation >= sysdate - 5 OR  v.modification >= sysdate - 5)"
-    ],
-    "random": [
-"    ORDER BY DBMS_RANDOM.VALUE FETCH NEXT 10 PERCENT ROWS ONLY"
     ]
   },
   "gob_mapping": {

--- a/src/data/verblijfsobjecten.json
+++ b/src/data/verblijfsobjecten.json
@@ -186,6 +186,12 @@
 "                     AND    q1.min_gebruiksdoel != 1) q7  ON v.verblijfseenheid_id = q7.verblijfsobject_id",
 "                                                         AND v.verblijfseenheidvolgnummer = q7.verblijfsobjectvolgnummer",
 "    WHERE    v.indauthentiek = 'J'"
+    ],
+    "last5days": [
+"        AND (v.creation >= sysdate - 5 OR  v.modification >= sysdate - 5)"
+    ],
+    "random": [
+"    ORDER BY DBMS_RANDOM.VALUE FETCH NEXT 10 PERCENT ROWS ONLY"
     ]
   },
   "gob_mapping": {

--- a/src/gobimport/__main__.py
+++ b/src/gobimport/__main__.py
@@ -8,6 +8,7 @@ from gobcore.message_broker.messagedriven_service import messagedriven_service
 
 from gobimport.import_client import ImportClient
 from gobimport.mapping import get_dataset_file_location, get_mapping
+from gobimport.config import FULL_IMPORT
 
 
 def extract_dataset_from_msg(msg):
@@ -44,7 +45,7 @@ def handle_import_msg(msg):
 
     # Create a new import client and start the process
     header = msg.get('header', {})
-    mode = header.get('mode', 'full')
+    mode = header.get('mode', FULL_IMPORT)
     import_client = ImportClient(dataset=dataset, msg=msg, mode=mode)
     return import_client.import_dataset()
 

--- a/src/gobimport/__main__.py
+++ b/src/gobimport/__main__.py
@@ -43,7 +43,9 @@ def handle_import_msg(msg):
     dataset = get_mapping(dataset_file)
 
     # Create a new import client and start the process
-    import_client = ImportClient(dataset=dataset, msg=msg)
+    header = msg.get('header', {})
+    mode = header.get('mode', 'full')
+    import_client = ImportClient(dataset=dataset, msg=msg, mode=mode)
     return import_client.import_dataset()
 
 

--- a/src/gobimport/config.py
+++ b/src/gobimport/config.py
@@ -5,6 +5,8 @@ from sqlalchemy.engine.url import URL
 
 from gobcore.exceptions import GOBException
 
+FULL_IMPORT = "full"
+
 ORACLE_DRIVER = 'oracle+cx_oracle'
 POSTGRES_DRIVER = 'postgresql'
 

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -38,7 +38,9 @@ class ImportClient:
 
     n_rows = 0
 
-    def __init__(self, dataset, msg):
+    def __init__(self, dataset, msg, mode):
+        self.mode = mode
+
         self.init_dataset(dataset)
 
         self.entity_validator = EntityValidator(self.catalogue, self.entity, self.func_source_id)
@@ -60,7 +62,7 @@ class ImportClient:
 
         # Log start of import process
         logger.configure(msg, "IMPORT")
-        logger.info(f"Import dataset {self.entity} from {self.source_app} started")
+        logger.info(f"Import dataset {self.entity} from {self.source_app} (mode = {self.mode}) started")
 
     def init_dataset(self, dataset):
         self.dataset = dataset
@@ -128,7 +130,7 @@ class ImportClient:
 
         logger.info(f"Start import from {self.source_app}")
         self.n_rows = 0
-        for row in reader.read():
+        for row in reader.read(self.mode):
             progress.tick()
 
             self.row = row

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -27,6 +27,7 @@ from gobimport.merger import Merger
 from gobimport.validator import Validator
 from gobimport.enricher import Enricher
 from gobimport.entity_validator import EntityValidator
+from gobimport.config import FULL_IMPORT
 
 
 class ImportClient:
@@ -38,7 +39,7 @@ class ImportClient:
 
     n_rows = 0
 
-    def __init__(self, dataset, msg, mode):
+    def __init__(self, dataset, msg, mode=FULL_IMPORT):
         self.mode = mode
 
         self.init_dataset(dataset)

--- a/src/gobimport/reader.py
+++ b/src/gobimport/reader.py
@@ -94,23 +94,26 @@ class Reader:
         else:
             yield from query
 
-    def read(self):  # noqa: C901
+    def read(self, mode):  # noqa: C901
         """Read the data from the data source
 
         :return: iterable dataset
         """
         assert self._connection is not None, "No connection, connect should succeed before read"
 
+        # The source query is the query, optionally populated with the mode (partial or full)
+        source_query = self.source["query"] + self.source.get(mode, [])
+
         if self.source['type'] == "file":
             query = query_file(self._connection)
         elif self.source['type'] == "database":
-            query = query_database(self._connection, self.source["query"])
+            query = query_database(self._connection, source_query)
         elif self.source['type'] == "oracle":
-            query = query_oracle(self._connection, self.source["query"])
+            query = query_oracle(self._connection, source_query)
         elif self.source['type'] == "objectstore":
             query = query_objectstore(self._connection, self.source)
         elif self.source['type'] == "postgres":
-            query = query_postgresql(self._connection, self.source["query"])
+            query = query_postgresql(self._connection, source_query)
         elif self.source['type'] == "wfs":
             query = query_wfs(self._connection)
         else:

--- a/src/gobimport/reader.py
+++ b/src/gobimport/reader.py
@@ -101,8 +101,8 @@ class Reader:
         """
         assert self._connection is not None, "No connection, connect should succeed before read"
 
-        # The source query is the query
-        source_query = self.source["query"]
+        # The source query is the query (only db-like connections have one)
+        source_query = self.source.get("query", [])
         if mode != FULL_IMPORT:
             # Optionally populated with the mode, eg partial, random, ...
             source_query += self.source[mode]

--- a/src/gobimport/reader.py
+++ b/src/gobimport/reader.py
@@ -94,7 +94,7 @@ class Reader:
         else:
             yield from query
 
-    def read(self, mode):  # noqa: C901
+    def read(self, mode=FULL_IMPORT):  # noqa: C901
         """Read the data from the data source
 
         :return: iterable dataset

--- a/src/gobimport/reader.py
+++ b/src/gobimport/reader.py
@@ -24,7 +24,7 @@ from gobcore.database.reader import (
     query_postgresql,
     query_wfs
 )
-from gobimport.config import get_database_config, get_objectstore_config
+from gobimport.config import get_database_config, get_objectstore_config, FULL_IMPORT
 
 
 class Reader:
@@ -101,8 +101,11 @@ class Reader:
         """
         assert self._connection is not None, "No connection, connect should succeed before read"
 
-        # The source query is the query, optionally populated with the mode (partial or full)
-        source_query = self.source["query"] + self.source.get(mode, [])
+        # The source query is the query
+        source_query = self.source["query"]
+        if mode != FULL_IMPORT:
+            # Optionally populated with the mode, eg partial, random, ...
+            source_query += self.source[mode]
 
         if self.source['type'] == "file":
             query = query_file(self._connection)

--- a/src/gobimport/reader.py
+++ b/src/gobimport/reader.py
@@ -104,8 +104,12 @@ class Reader:
         # The source query is the query (only db-like connections have one)
         source_query = self.source.get("query", [])
         if mode != FULL_IMPORT:
-            # Optionally populated with the mode, eg partial, random, ...
-            source_query += self.source[mode]
+            try:
+                # Optionally populated with the mode, eg partial, random, ...
+                source_query += self.source[mode]
+            except KeyError as e:
+                logger.error(f"Unknown import mode for the collection: '{mode}'")
+                raise e
 
         if self.source['type'] == "file":
             query = query_file(self._connection)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.9.6#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.9.8#egg=gobcore
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from gobcore.exceptions import GOBException
 from gobimport.__main__ import handle_import_msg, SERVICEDEFINITION, extract_dataset_from_msg
+from gobimport.config import FULL_IMPORT
 
 
 class TestMain(TestCase):
@@ -28,7 +29,7 @@ class TestMain(TestCase):
         mock_extract_dataset.assert_called_with(self.mock_msg)
         mock_get_mapping.assert_called_with("dataset_file")
 
-        mock_import_client.assert_called_with(dataset="mapped_file", msg=self.mock_msg)
+        mock_import_client.assert_called_with(dataset="mapped_file", msg=self.mock_msg, mode=FULL_IMPORT)
         mock_import_client_instance.import_dataset.assert_called_once()
 
     @patch("gobimport.__main__.get_dataset_file_location")

--- a/src/tests/test_reader.py
+++ b/src/tests/test_reader.py
@@ -81,6 +81,15 @@ class TestReader(unittest.TestCase):
 
                  mock_read.assert_called()
 
+        # If a mode is specified the mode query extension should be read from the config
+        with self.assertRaises(KeyError):
+            # Non-existent mode
+            reader.read(mode="some mode")
+
+        # Existent mode
+        self.source["my mode"] = "my mode"
+        reader.read(mode="my mode")
+
         # Assert not implemented is raised with undefined read type
         with self.assertRaises(NotImplementedError):
             reader.source['type'] = "any type"


### PR DESCRIPTION
Add a demo import mode for metingen: some_day
Add an import mode for verblijfsobjecten: recent

Large imports should all get a "recent" import mode to only import recently added or changed entities.

Partial imports can be started using for example:
python -m gobworkflow.start import meetbouten metingen "" some_day

This PR depends on the corresponding PR for gobupload to handle partial uploads