### PR TITLE
Release update Core for QA "betwijfelde waarde"

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.1#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.1a#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.3.2b#egg=gobconfig
 jsonschema==2.6.0
 mccabe==0.6.1


### PR DESCRIPTION
QA update stores the string value of any "betwijfelde waarde"

A "betwijfelde waarde" can be of any type.
When the type is a Decimal for instance the JSON serialisation would fail in the upload process
By converting the value to a string the string representation is stored and any serialisation errors are prevented