### PR TITLE
Update Config, remove dry_run for Amsterdamse Sleutel

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
 -e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.9c#egg=gobcore
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.2b#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.2-no_dry_run#egg=gobconfig
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5


### PR DESCRIPTION
Without the dry_run parameter GOB will generate the Amsterdamse Sleutel
Before, this was done by DIVA