### PR TITLE
PGB 1280 string in numeriek veld

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,8 +3,8 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.2#egg=gobcore
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.5#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.3#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.6#egg=gobconfig
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5

--- a/src/test.sh
+++ b/src/test.sh
@@ -13,4 +13,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobimport --cov-report html --cov-fail-under=88
+pytest --cov=gobimport --cov-report html --cov-fail-under=89


### PR DESCRIPTION
Log a data error when a type conversion fails.

Before this change the GOB-Import process would crash.
Now all type conversion errors are reported as data-errors.
This stops any further processing but the use can still see the data-errors.