### PR TITLE
Changed QA level from fatal to warning for documentnummer

### DIFF
--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -187,7 +187,7 @@ ENTITY_CHECKS = {
         "documentnummer": [
             {
                 **QA_CHECK.Value_brondocument_coding,
-                "level": QA_LEVEL.FATAL,
+                "level": QA_LEVEL.WARNING,
             }
         ]
     }


### PR DESCRIPTION
Checks with a level of fatal will stop the import process, that should not happen for this data error