### PR TITLE
Wkpb import changes and qa check peilmerken fixed

### DIFF
--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -82,7 +82,7 @@ ENTITY_CHECKS = {
         ],
     },
     "rollagen": {
-        "name": [
+        "identificatie": [
             {
                 **QA_CHECK.Format_AAN_AANN,
                 "level": QA_LEVEL.FATAL,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
 -e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.11#egg=gobcore
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11k#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11l#egg=gobconfig
 jsonschema==2.6.0
 mccabe==0.6.1
 numpy==1.14.5


### PR DESCRIPTION
This PR contains 2 changes:
- Updated gob-config version so correct queries are used for importing WKPB dossiers and brondocumenten
- Modified QA check for peilmerken from unused name field to identificatie