### PR TITLE
Fix import. Show error instead of dataerror when import of object fai…

### DIFF
--- a/src/gobimport/converter.py
+++ b/src/gobimport/converter.py
@@ -14,7 +14,6 @@ from gobcore.model import GOBModel
 from gobcore.model.metadata import FIELD
 from gobcore.exceptions import GOBException, GOBTypeException
 from gobcore.logging.logger import logger
-from gobcore.quality.issue import QA_CHECK, QA_LEVEL, Issue, log_issue
 
 
 class Converter:
@@ -289,13 +288,9 @@ def _extract_field(row, field, metadata, typeinfo, entity_id_field=None, seqnr_f
         # Convert the raw source row into a GOB-like row
         report_row = _goblike_row(row, entity_id_field, seqnr_field)
         report_row[field] = value
-        log_issue(logger,
-                  QA_LEVEL.ERROR,
-                  Issue(QA_CHECK.Value_should_match,
-                        report_row,
-                        id_attribute=FIELD.ID,
-                        attribute=field,
-                        compared_to=f'type {field_type}'))
+
+        id = report_row[FIELD.ID] + (f".{report_row[FIELD.SEQNR]}" if seqnr_field else "")
+        logger.error(f"Error importing object with id {id}. Can't extract value for field {field}")
         return gob_type.from_value_secure(None, typeinfo, **kwargs)
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.0f#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.1#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.12d#egg=gobconfig
 jsonschema==2.6.0
 mccabe==0.6.1

--- a/src/tests/test_converter.py
+++ b/src/tests/test_converter.py
@@ -364,12 +364,13 @@ class TestConverter(unittest.TestCase):
         result = _extract_references(row, source, field_type)
         self.assertEqual(result, [{'bronwaarde': 'aap'}, {'bronwaarde': 'mies'}, {'bronwaarde': 'noot'}])
 
-    @mock.patch('gobimport.converter.logger', mock.MagicMock())
-    @mock.patch('gobimport.converter.Issue', mock.MagicMock())
+    @mock.patch('gobimport.converter.logger')
     @mock.patch('gobimport.converter.get_gob_type_from_info')
     @mock.patch('gobimport.converter._get_value')
-    def test_extract_field(self, mock_get_value, mock_get_gob_type_from_info):
-        row = {}
+    def test_extract_field(self, mock_get_value, mock_get_gob_type_from_info, mock_logger):
+        row = {
+            '_id': '12345',
+        }
         field = 'f'
         metadata = {
             'source_mapping': 'any mapping'
@@ -390,3 +391,6 @@ class TestConverter(unittest.TestCase):
         mock_gob_type.from_value_secure.side_effect = [GOBTypeException(), None]
         result = _extract_field(row, field, metadata, typeinfo)
         self.assertEqual(result, None)
+
+        # Assert error is generated
+        mock_logger.error.assert_called_once()


### PR DESCRIPTION
…ls. Update core with updated WOZ model

When import fails, dataerror has no object to relate to. Show an error instead (which fails the import as well).