### PR TITLE
Change qa check to check omschrijving

### DIFF
--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -222,7 +222,7 @@ ENTITY_CHECKS = {
                     "level": QA_LEVEL.WARNING
                 },
             ],
-            "redenopvoer": [
+            "redenopvoer.omschrijving": [
                 {
                     "source_app": "Neuron",
                     **QA_CHECK.Value_not_empty,


### PR DESCRIPTION
The value was a JSON object, so we need to check if the omschrijving is empty