### PR TITLE
Import as standalone application (#728)

### DIFF
--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -27,6 +27,8 @@ from gobimport.merger import Merger
 from gobimport.reader import Reader
 from gobimport.validator import Validator
 
+from typing import Optional
+
 
 class ImportClient:
     """Main class for an import client
@@ -146,11 +148,11 @@ class ImportClient:
             # Default requirement for full imports is a non-empty dataset
             self.logger.error(f"Too few records imported: {self.n_rows} < {min_rows}")
 
-    def import_dataset(self):
+    def import_dataset(self, destination: Optional[str] = None):
         try:
             self.row = None
 
-            with ContentsWriter() as writer, \
+            with ContentsWriter(destination) as writer, \
                     ProgressTicker(f"Import {self.catalogue} {self.entity}", 10000) as progress:
 
                 self.filename = writer.filename

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.5.0#egg=gobconfig
--e git+https://github.com/Amsterdam/GOB-Core.git@v1.0.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v1.2.1#egg=gobcore

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1,10 +1,10 @@
+from io import StringIO
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from gobcore.exceptions import GOBException
-
-from gobimport.__main__ import ImportMode, \
-    SERVICEDEFINITION, extract_dataset_from_msg, handle_import_msg, handle_import_object_msg
+from gobimport.__main__ import ImportMode, extract_dataset_from_msg, handle_import_msg, handle_import_object_msg, \
+    SERVICEDEFINITION, main, run_as_standalone
 
 
 class TestMain(TestCase):
@@ -21,13 +21,7 @@ class TestMain(TestCase):
     @patch("gobimport.__main__.ImportClient")
     @patch("gobimport.__main__.extract_dataset_from_msg")
     def test_handle_import_msg(self, mock_extract_dataset, mock_import_client, mock_logger):
-        """Tests handle_import_msg for a normal import
-
-        :param mock_extract_dataset:
-        :param mock_import_client:
-        :param mock_logger:
-        :return:
-        """
+        """Tests handle_import_msg for a normal import."""
         mock_import_client_instance = MagicMock()
         mock_import_client.return_value = mock_import_client_instance
         mock_extract_dataset.return_value = {
@@ -40,6 +34,7 @@ class TestMain(TestCase):
         }
         handle_import_msg(self.mock_msg)
 
+        mock_logger.add_message_broker_handler.assert_called_once()
         mock_extract_dataset.assert_called_with(self.mock_msg)
 
         mock_import_client.assert_called_with(
@@ -49,6 +44,7 @@ class TestMain(TestCase):
             logger=mock_logger,
         )
         mock_import_client_instance.import_dataset.assert_called_once()
+        mock_import_client_instance.import_dataset.assert_called_with()  # no args
 
         self.assertEqual({
             'dataset_file': 'data/somefile.json',
@@ -61,6 +57,51 @@ class TestMain(TestCase):
             }
 
         }, self.mock_msg)
+
+    @patch("gobimport.__main__.WorkflowCommands")
+    @patch("gobimport.__main__.logger")
+    @patch("gobimport.__main__.ImportClient")
+    @patch("gobimport.__main__.extract_dataset_from_msg")
+    def test_run_as_standalone(self, mock_extract_dataset, mock_import_client, mock_logger, mock_wfc):
+        mock_import_client_instance = MagicMock()
+        mock_import_client.return_value = mock_import_client_instance
+        mock_import_client_instance.import_dataset.return_value.get = lambda x: "/path"
+        mock_extract_dataset.return_value = {
+            "source": {
+                "name": "Some source",
+                "application": "The application",
+            },
+            "catalogue": "CAT",
+            "entity": "ENT"
+        }
+        args = {
+            "catalogue": "CAT",
+            "collection": "ENT",
+            "application": "The application",
+            "mode": "recent"
+        }
+        run_as_standalone(args)
+
+        mock_logger.add_message_broker_handler.assert_not_called()
+        mock_logger.info(f"Imported collection to: /path")
+        mock_extract_dataset.assert_called_with({"header": args})
+
+        msg = {
+            "header": {
+                "catalogue": "CAT",
+                "source": "Some source",
+                "application": "The application",
+                "entity": "ENT",
+            }
+        }
+
+        mock_import_client.assert_called_with(
+            dataset=mock_extract_dataset.return_value,
+            msg=msg,
+            mode=ImportMode.RECENT,
+            logger=mock_logger,
+        )
+        mock_import_client_instance.import_dataset.assert_called_with("CAT/ENT")
 
     @patch("gobimport.__main__.logger")
     @patch("gobimport.__main__.MappinglessConverterAdapter")
@@ -124,8 +165,52 @@ class TestMain(TestCase):
                 extract_dataset_from_msg({'header': case})
 
     @patch("gobimport.__main__.messagedriven_service")
-    def test_main_entry(self, mock_messagedriven_service):
-        from gobimport import __main__ as module
-        with patch.object(module, "__name__", "__main__"):
-            module.init()
+    def test_main_entry_message_broker(self, mock_messagedriven_service):
+        from gobimport.__main__ import sys
+
+        with patch.object(sys, "argv", ["gobimport"]):
+            main()
             mock_messagedriven_service.assert_called_with(SERVICEDEFINITION, "Import")
+
+    @patch("gobimport.__main__.run_as_standalone")
+    def test_main_entry_standalone(self, mock_run):
+        from gobimport.__main__ import sys
+
+        with patch.object(sys, "argv", ["gobimport", "import", "bag", "ligplaatsen", "Neuron"]):
+            main()
+            mock_run.assert_called_with(
+                {
+                    "catalogue": "bag",
+                    "collection": "ligplaatsen",
+                    "application": "Neuron",
+                    "mode": "full"
+                }
+            )
+
+        args = ["gobimport", "import", "bag", "ligplaatsen", "Neuron", "recent"]
+        with patch.object(sys, "argv", args):
+            main()
+            mock_run.assert_called_with(
+                {
+                    "catalogue": "bag",
+                    "collection": "ligplaatsen",
+                    "application": "Neuron",
+                    "mode": "recent"
+                }
+            )
+
+        with (
+            patch.object(sys, "argv", ["gobimport", "import", "gebieden"]),
+            patch('sys.stderr', new_callable=StringIO) as mock_stderr
+        ):
+            err = "gobimport: error: the following arguments are required: collection"
+            self.assertRaisesRegex(SystemExit, "2", main)
+            self.assertEqual(err, mock_stderr.getvalue().splitlines()[-1])
+
+        with (
+            patch.object(sys, "argv", ["gobimport", "import"]),
+            patch('sys.stderr', new_callable=StringIO) as mock_stderr
+        ):
+            err = "gobimport: error: the following arguments are required: catalogue, collection"
+            self.assertRaisesRegex(SystemExit, "2", main)
+            self.assertEqual(err, mock_stderr.getvalue().splitlines()[-1])


### PR DESCRIPTION
* Import as standalone application

- if args are given, start standalone
- no args, connect to messagebroker

* Use WorkflowCommands from gob-core

* refactor handle_import_msg for standalone

* Update core

- Use as standalone app

* Use Optional typing on argument

* Update core