### PR TITLE
Remove logging configure

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.7.0#egg=gobconfig
--e git+https://github.com/Amsterdam/GOB-Core.git@v1.8.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v1.9.0#egg=gobcore


### PR DESCRIPTION
- The logger is configured in gob-core version >= _v1.9.0_ in `_on_message` 
- Not necessary to configure this in the handler anymore. 
- Applies to worfklow and standalone mode