### PR TITLE
Don't validate merged entities twice

### DIFF
--- a/src/gobimport/entity_validator/__init__.py
+++ b/src/gobimport/entity_validator/__init__.py
@@ -28,14 +28,14 @@ class EntityValidator:
             if Validator.validates(catalog_name, entity_name):
                 self.validators.append(Validator(catalog_name, entity_name, source_id))
 
-    def validate(self, entity):
+    def validate(self, entity, **kwargs):
         """Validate the entity for all applicable validation tests.
 
         :param entity:
         :return: None
         """
         for validator in self.validators:
-            validator.validate(entity)
+            validator.validate(entity, **kwargs)
 
     def result(self):
         """Checks for fatal errors.

--- a/src/gobimport/entity_validator/bag.py
+++ b/src/gobimport/entity_validator/bag.py
@@ -52,7 +52,7 @@ class BAGValidator:
     def result(self):
         return self.validated
 
-    def validate(self, entity):
+    def validate(self, entity, **kwargs):
         # Only validate objects from Amsterdam (0363) since Weesp does not have the plus-gegevens
         if entity.get('identificatie', '').startswith('0363'):
             self.validate_entity(entity)

--- a/src/gobimport/entity_validator/gebieden.py
+++ b/src/gobimport/entity_validator/gebieden.py
@@ -36,7 +36,7 @@ class GebiedenValidator:
     def result(self):
         return self.validated
 
-    def validate(self, entity):
+    def validate(self, entity, **kwargs):
         self.validate_entity(entity)
 
     def validate_bouwblok(self, entity):

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -186,10 +186,10 @@ class ImportClient:
 
             entity = self.converter.convert(row)
 
-            # validator and entity_validator build up sets of primary keys from the dataset
-            # -> higher memory consumption
             self.validator.validate(entity)
-            self.entity_validator.validate(entity)
+
+            # if the current entity is also merged, drop the first cached entity
+            self.entity_validator.validate(entity, drop=self.merger.is_merged(entity))
 
             write(entity)
 

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -188,8 +188,7 @@ class ImportClient:
 
             self.validator.validate(entity)
 
-            # if the current entity is also merged, drop the first cached entity
-            self.entity_validator.validate(entity, drop=self.merger.is_merged(entity))
+            self.entity_validator.validate(entity, merged=self.merger.is_merged(entity))
 
             write(entity)
 

--- a/src/gobimport/merger.py
+++ b/src/gobimport/merger.py
@@ -97,6 +97,9 @@ class Merger:
 
             self.merge_def = merge_def
 
+    def is_merged(self, entity) -> bool:
+        return self.merge_def and entity[self.merge_def["on"]] in self.merged
+
     def merge(self, entity, write):
         """
         If a merge definition exists for the current dataset, the entity is merged with the entities in merge_items
@@ -106,12 +109,9 @@ class Merger:
         """
         if self.merge_def:
             on = self.merge_def["on"]
-            merge_item = self.merge_items.get(entity[on])
-            if merge_item:
-                entities = merge_item["entities"]
 
-                self.merge_func(entity, write, entities)
-
+            if merge_item := self.merge_items.get(entity[on]):
+                self.merge_func(entity, write, merge_item["entities"])
                 self.merged.append(entity[on])
 
     def finish(self, write):

--- a/src/gobimport/merger.py
+++ b/src/gobimport/merger.py
@@ -114,6 +114,7 @@ class Merger:
         return (
             key in self.merged and
             key in self.merge_items and  # Merger.prepare: not all merge_items are populated yet
+            self.merge_items[key]["entities"] and
             self.merge_items[key]["entities"][-1][FIELD.SEQNR] == entity[FIELD.SEQNR]
         )
 

--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -124,13 +124,6 @@ ENTITY_CHECKS = {
     },
     "gebieden": {
         "bouwblokken": {
-            # "_source_id": [
-            #     {
-            #         "source_app": "DGDialog",
-            #         **QA_CHECK.Format_4_2_2_2_6_HEX_SEQ,
-            #         "level": QA_LEVEL.WARNING
-            #     }
-            # ],
             "code": [
                 {
                     **QA_CHECK.Format_AANN,

--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -124,19 +124,25 @@ ENTITY_CHECKS = {
     },
     "gebieden": {
         "bouwblokken": {
-            "_source_id": [
-                {
-                    "source_app": "DGDialog",
-                    **QA_CHECK.Format_4_2_2_2_6_HEX_SEQ,
-                    "level": QA_LEVEL.WARNING
-                }
-            ],
+            # "_source_id": [
+            #     {
+            #         "source_app": "DGDialog",
+            #         **QA_CHECK.Format_4_2_2_2_6_HEX_SEQ,
+            #         "level": QA_LEVEL.WARNING
+            #     }
+            # ],
             "code": [
                 {
                     **QA_CHECK.Format_AANN,
                     "level": QA_LEVEL.FATAL
                 }
             ],
+            "geometrie": [
+                {
+                    **QA_CHECK.Value_geometry_in_NL,
+                    "level": QA_LEVEL.FATAL,
+                }
+            ]
         },
         "buurten": {
             "geometrie": [

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.1#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.2#egg=gobconfig
 -e git+https://github.com/Amsterdam/GOB-Core.git@v1.10.0#egg=gobcore

--- a/src/tests/entity_validator/test_init.py
+++ b/src/tests/entity_validator/test_init.py
@@ -11,7 +11,7 @@ class TestEntityValidator(unittest.TestCase):
 
     def test_entity_result_ok(self):
         with patch.object(StateValidator, 'validates', lambda *args: True), \
-             patch.object(GebiedenValidator, 'validate', lambda *args: True):
+             patch.object(GebiedenValidator, 'validate', lambda *args, **kwargs: True):
             validator = EntityValidator("catalog", "collection", "id")
             self.assertTrue(validator.result())
 
@@ -34,9 +34,19 @@ class TestEntityValidator(unittest.TestCase):
 
     def test_entity_validate(self):
         with patch.object(StateValidator, 'validates', lambda *args: True), \
-             patch.object(StateValidator, 'validate', lambda *args: True), \
+             patch.object(StateValidator, 'validate', lambda *args, **kwargs: True), \
              patch.object(GebiedenValidator, 'validates', lambda *args: True), \
-             patch.object(GebiedenValidator, 'validate', lambda *args: False):
+             patch.object(GebiedenValidator, 'validate', lambda *args, **kwargs: False):
             validator = EntityValidator("catalog", "collection", "id")
             self.assertEqual(len(validator.validators), 2)
             self.assertIsNone(validator.validate("collection"))
+
+    @patch("gobimport.entity_validator.StateValidator", MagicMock())
+    @patch("gobimport.entity_validator.GebiedenValidator", MagicMock())
+    def test_validate_kwarg(self):
+        validator = EntityValidator("catalog", "collection", "id")
+        validator.validate("collection", custom_kwarg="kwarg1")
+
+        self.assertEquals(2, len(validator.validators))
+        for val in validator.validators:
+            val.validate.assert_called_with("collection", custom_kwarg="kwarg1")

--- a/src/tests/entity_validator/test_init.py
+++ b/src/tests/entity_validator/test_init.py
@@ -47,6 +47,6 @@ class TestEntityValidator(unittest.TestCase):
         validator = EntityValidator("catalog", "collection", "id")
         validator.validate("collection", custom_kwarg="kwarg1")
 
-        self.assertEquals(2, len(validator.validators))
+        self.assertEqual(2, len(validator.validators))
         for val in validator.validators:
             val.validate.assert_called_with("collection", custom_kwarg="kwarg1")

--- a/src/tests/test_import_client.py
+++ b/src/tests/test_import_client.py
@@ -106,6 +106,24 @@ class TestImportClient(TestCase):
         self.assertEqual(len(_self.logger.info.call_args_list), 3)
 
     @patch('gobimport.import_client.Reader')
+    def test_import_rows_merged(self, mock_Reader):
+        mock_reader = MagicMock()
+        mock_Reader.return_value = mock_reader
+        rows = ((1, 2), (3, 4))
+        mock_reader.read.return_value = rows
+
+        progress = MagicMock()
+        write = MagicMock()
+
+        _self = MagicMock()
+        _self.converter.convert.return_value = 'Entity'
+
+        _self.merger.is_merged = lambda x: True
+
+        ImportClient.import_rows(_self, write, progress)
+        _self.entity_validator.validate.assert_called_with("Entity", drop=True)
+
+    @patch('gobimport.import_client.Reader')
     def test_import_row_too_few_records(self, mock_Reader):
         reader = MagicMock()
         mock_Reader.return_value = reader

--- a/src/tests/test_import_client.py
+++ b/src/tests/test_import_client.py
@@ -121,7 +121,7 @@ class TestImportClient(TestCase):
         _self.merger.is_merged = lambda x: True
 
         ImportClient.import_rows(_self, write, progress)
-        _self.entity_validator.validate.assert_called_with("Entity", drop=True)
+        _self.entity_validator.validate.assert_called_with("Entity", merged=True)
 
     @patch('gobimport.import_client.Reader')
     def test_import_row_too_few_records(self, mock_Reader):

--- a/src/tests/test_merger.py
+++ b/src/tests/test_merger.py
@@ -116,6 +116,17 @@ class TestMerger(unittest.TestCase):
         }, merge_def)
         self.assertEqual(len(merger.merge_items["b"]["entities"]), 2)
 
+    def test_is_merged(self):
+        merger = Merger(None)
+        entity = {"b": "value2", "volgnummer": 1}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merge_def = {"on": "b"}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merged = ["value2"]
+        self.assertTrue(merger.is_merged(entity))
+
     @mock.patch('gobimport.merger.get_import_definition_by_filename', mock.MagicMock())
     def test_merge(self):
         mock_client = mock.MagicMock(spec=ImportClient)
@@ -152,6 +163,3 @@ class TestMerger(unittest.TestCase):
         self.assertIsNone(merger.merge_items.get(1))
         self.assertIsNone(merger.merge_items.get(2))
         self.assertEqual(len(finished), 1)
-
-    def test_finish(self):
-        pass

--- a/src/tests/test_merger.py
+++ b/src/tests/test_merger.py
@@ -124,7 +124,13 @@ class TestMerger(unittest.TestCase):
         merger.merge_def = {"on": "b"}
         self.assertFalse(merger.is_merged(entity))
 
-        merger.merged = ["value2"]
+        merger.merged = {"value2"}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merge_items["value2"] = {"entities": []}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merge_items["value2"] = {"entities": [entity]}
         self.assertTrue(merger.is_merged(entity))
 
     @mock.patch('gobimport.merger.get_import_definition_by_filename', mock.MagicMock())


### PR DESCRIPTION
Problem: 
A 'merged' dataset imports from 2 different sources and merges certain fields for both entities. We validate the states of an entity in the EntityValidator, called during import. The issue doesn't appear in case of two different `entity_id`s, configured in gob-config. This because we cache these `entity_id` as key for the states. This is equal to validating 2 separate datasets, because the `entity_id` (probably) never match. In the bouwblokken case, the `entity_id` is the same, so the StateValidator errors on encountering the same volgnummer for an entity.

During importing a merged dataset we pass the `EntityValidator` two times:
- Merger.prepare, which adds all (to be merged) entities to the volgnummers and enddate cache. 
- the actual import, we validate the now merged entity again.

The second time we want to validate the _complete_ (incl merged) dataset. 

Temporary solution until this functionality is merged into GOB-Prepare:
Skip logging an issue for merged entities. 