### PR TITLE
Don't validate merged entities twice (#767)

### DIFF
--- a/src/gobimport/entity_validator/__init__.py
+++ b/src/gobimport/entity_validator/__init__.py
@@ -28,14 +28,14 @@ class EntityValidator:
             if Validator.validates(catalog_name, entity_name):
                 self.validators.append(Validator(catalog_name, entity_name, source_id))
 
-    def validate(self, entity):
+    def validate(self, entity, **kwargs):
         """Validate the entity for all applicable validation tests.
 
         :param entity:
         :return: None
         """
         for validator in self.validators:
-            validator.validate(entity)
+            validator.validate(entity, **kwargs)
 
     def result(self):
         """Checks for fatal errors.

--- a/src/gobimport/entity_validator/bag.py
+++ b/src/gobimport/entity_validator/bag.py
@@ -52,7 +52,7 @@ class BAGValidator:
     def result(self):
         return self.validated
 
-    def validate(self, entity):
+    def validate(self, entity, **kwargs):
         # Only validate objects from Amsterdam (0363) since Weesp does not have the plus-gegevens
         if entity.get('identificatie', '').startswith('0363'):
             self.validate_entity(entity)

--- a/src/gobimport/entity_validator/gebieden.py
+++ b/src/gobimport/entity_validator/gebieden.py
@@ -36,7 +36,7 @@ class GebiedenValidator:
     def result(self):
         return self.validated
 
-    def validate(self, entity):
+    def validate(self, entity, **kwargs):
         self.validate_entity(entity)
 
     def validate_bouwblok(self, entity):

--- a/src/gobimport/entity_validator/state.py
+++ b/src/gobimport/entity_validator/state.py
@@ -30,7 +30,7 @@ class StateValidator:
     def result(self):
         return self.validated
 
-    def validate(self, entity):
+    def validate(self, entity, merged: bool = False):
         """
         Validate entity with state to see if generic validations for states are correct.
 
@@ -39,11 +39,36 @@ class StateValidator:
         - begin_geldigheid should not be after eind_geldigheid (when filled)
         - volgnummer should be a positive number and unique in the collection
 
+        When `entity` is merged, return early because this is entity is already checked.
+
         :param entity: a GOB entity
+        :param merged: bool
         :return:
         """
         self._validate_begin_geldigheid(entity)
+        self._validate_volgnummer(entity)
+        identificatie = str(entity[self.source_id])
 
+        if merged:
+            # in case Merger.prepare set this id to True and the current entity has end validity yes/no
+            self.end_date[identificatie] = entity[FIELD.END_VALIDITY] is None
+            return
+
+        if entity[FIELD.SEQNR] in self.volgnummers[identificatie]:
+            log_issue(logger, QA_LEVEL.ERROR,
+                      Issue(QA_CHECK.Value_unique, entity, self.source_id, FIELD.SEQNR))
+            self.validated = False
+
+        self.volgnummers[identificatie].add(entity[FIELD.SEQNR])
+
+        # Only one eind_geldigheid may be empty per entity (non-merged)
+        if entity[FIELD.END_VALIDITY] is None:
+            if self.end_date.get(identificatie):
+                log_issue(logger, QA_LEVEL.WARNING,
+                          Issue(QA_CHECK.Value_empty_once, entity, self.source_id, FIELD.END_VALIDITY))
+            self.end_date[identificatie] = True
+
+    def _validate_volgnummer(self, entity):
         # Volgnummer can't be empty -> Fatal
         if entity[FIELD.SEQNR] is None:
             log_issue(logger, QA_LEVEL.FATAL,
@@ -55,22 +80,6 @@ class StateValidator:
             log_issue(logger, QA_LEVEL.ERROR,
                       Issue(QA_CHECK.Format_numeric, entity, self.source_id, FIELD.SEQNR))
             self.validated = False
-
-        identificatie = str(entity[self.source_id])
-        if entity[FIELD.SEQNR] in self.volgnummers[identificatie]:
-            log_issue(logger, QA_LEVEL.ERROR,
-                      Issue(QA_CHECK.Value_unique, entity, self.source_id, FIELD.SEQNR))
-            self.validated = False
-
-        # Only one eind_geldigheid may be empty per entity
-        if entity[FIELD.END_VALIDITY] is None:
-            if self.end_date.get(identificatie):
-                log_issue(logger, QA_LEVEL.WARNING,
-                          Issue(QA_CHECK.Value_empty_once, entity, self.source_id, FIELD.END_VALIDITY))
-            self.end_date[identificatie] = True
-
-        # Add the volgnummer to the set for this entity identificatie
-        self.volgnummers[identificatie].add(entity[FIELD.SEQNR])
 
     def _validate_begin_geldigheid(self, entity):
         if entity[FIELD.START_VALIDITY]:

--- a/src/gobimport/import_client.py
+++ b/src/gobimport/import_client.py
@@ -186,10 +186,9 @@ class ImportClient:
 
             entity = self.converter.convert(row)
 
-            # validator and entity_validator build up sets of primary keys from the dataset
-            # -> higher memory consumption
             self.validator.validate(entity)
-            self.entity_validator.validate(entity)
+
+            self.entity_validator.validate(entity, merged=self.merger.is_merged(entity))
 
             write(entity)
 

--- a/src/gobimport/merger.py
+++ b/src/gobimport/merger.py
@@ -16,6 +16,7 @@ When large data collections need to be merged then GOB-Prepare is considered a b
 Data can then be merged using a database
 """
 from gobconfig.import_.import_config import get_import_definition_by_filename
+from gobcore.model import FIELD
 
 
 class Merger:
@@ -30,7 +31,7 @@ class Merger:
         self.import_client = import_client
         self.merge_def = None
         self.merge_items = {}
-        self.merged = []
+        self.merged = set()
 
     def _collect_entity(self, entity, merge_def):
         """
@@ -59,6 +60,7 @@ class Merger:
 
         if entity["volgnummer"] == 1:
             # Write the previous entities before the first new entity
+            # This will skip merge_entity defined above
             for diva_entity in entities[:-1]:
                 write(diva_entity)
 
@@ -97,6 +99,25 @@ class Merger:
 
             self.merge_def = merge_def
 
+    def is_merged(self, entity) -> bool:
+        """
+        Returns whether an entity is a 'merged' entity.
+        This is the case if True:
+         - key is added to self.merged
+         - the last volgnummer from merge_entities is equal to `entity` volgnummer
+        """
+        if self.merge_def is None:
+            return False
+
+        on = self.merge_def["on"]
+        key = entity[on]
+        return (
+            key in self.merged and
+            key in self.merge_items and  # Merger.prepare: not all merge_items are populated yet
+            self.merge_items[key]["entities"] and
+            self.merge_items[key]["entities"][-1][FIELD.SEQNR] == entity[FIELD.SEQNR]
+        )
+
     def merge(self, entity, write):
         """
         If a merge definition exists for the current dataset, the entity is merged with the entities in merge_items
@@ -106,13 +127,10 @@ class Merger:
         """
         if self.merge_def:
             on = self.merge_def["on"]
-            merge_item = self.merge_items.get(entity[on])
-            if merge_item:
-                entities = merge_item["entities"]
 
-                self.merge_func(entity, write, entities)
-
-                self.merged.append(entity[on])
+            if merge_item := self.merge_items.get(entity[on]):
+                self.merge_func(entity, write, merge_item["entities"])
+                self.merged.add(entity[on])
 
     def finish(self, write):
         """

--- a/src/gobimport/validator/__init__.py
+++ b/src/gobimport/validator/__init__.py
@@ -124,19 +124,18 @@ ENTITY_CHECKS = {
     },
     "gebieden": {
         "bouwblokken": {
-            "_source_id": [
-                {
-                    "source_app": "DGDialog",
-                    **QA_CHECK.Format_4_2_2_2_6_HEX_SEQ,
-                    "level": QA_LEVEL.WARNING
-                }
-            ],
             "code": [
                 {
                     **QA_CHECK.Format_AANN,
                     "level": QA_LEVEL.FATAL
                 }
             ],
+            "geometrie": [
+                {
+                    **QA_CHECK.Value_geometry_in_NL,
+                    "level": QA_LEVEL.FATAL,
+                }
+            ]
         },
         "buurten": {
             "geometrie": [

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.1#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.2#egg=gobconfig
 -e git+https://github.com/Amsterdam/GOB-Core.git@v1.10.0#egg=gobcore

--- a/src/tests/entity_validator/test_init.py
+++ b/src/tests/entity_validator/test_init.py
@@ -11,7 +11,7 @@ class TestEntityValidator(unittest.TestCase):
 
     def test_entity_result_ok(self):
         with patch.object(StateValidator, 'validates', lambda *args: True), \
-             patch.object(GebiedenValidator, 'validate', lambda *args: True):
+             patch.object(GebiedenValidator, 'validate', lambda *args, **kwargs: True):
             validator = EntityValidator("catalog", "collection", "id")
             self.assertTrue(validator.result())
 
@@ -34,9 +34,19 @@ class TestEntityValidator(unittest.TestCase):
 
     def test_entity_validate(self):
         with patch.object(StateValidator, 'validates', lambda *args: True), \
-             patch.object(StateValidator, 'validate', lambda *args: True), \
+             patch.object(StateValidator, 'validate', lambda *args, **kwargs: True), \
              patch.object(GebiedenValidator, 'validates', lambda *args: True), \
-             patch.object(GebiedenValidator, 'validate', lambda *args: False):
+             patch.object(GebiedenValidator, 'validate', lambda *args, **kwargs: False):
             validator = EntityValidator("catalog", "collection", "id")
             self.assertEqual(len(validator.validators), 2)
             self.assertIsNone(validator.validate("collection"))
+
+    @patch("gobimport.entity_validator.StateValidator", MagicMock())
+    @patch("gobimport.entity_validator.GebiedenValidator", MagicMock())
+    def test_validate_kwarg(self):
+        validator = EntityValidator("catalog", "collection", "id")
+        validator.validate("collection", custom_kwarg="kwarg1")
+
+        self.assertEqual(2, len(validator.validators))
+        for val in validator.validators:
+            val.validate.assert_called_with("collection", custom_kwarg="kwarg1")

--- a/src/tests/entity_validator/test_state_validator.py
+++ b/src/tests/entity_validator/test_state_validator.py
@@ -150,3 +150,31 @@ class TestEntityValidator(unittest.TestCase):
 
             # Expect Log Issue to be called
             mock_log_issue.assert_called()
+
+    def test_validate_merged(self):
+        entity = \
+            {
+                'identificatie': '1234567890',
+                'volgnummer': 1,
+                'begin_geldigheid': datetime.datetime(2018, 1, 1),
+                'eind_geldigheid': None,
+            }
+        source_id = "identificatie"
+
+        with patch("gobimport.entity_validator.state.log_issue") as mock_log_issue:
+            validator = StateValidator('catalogue', 'collection', source_id)
+            validator.validate(entity, merged=True)
+
+            self.assertTrue(validator.result())
+            self.assertNotIn(entity[source_id], validator.volgnummers)
+            self.assertTrue(validator.end_date[entity[source_id]])
+            mock_log_issue.assert_not_called()
+
+            # eind_geldigheid is not None
+            entity["eind_geldigheid"] = datetime.datetime(2020, 10, 10, 12)
+            validator.validate(entity, merged=True)
+
+            self.assertTrue(validator.result())
+            self.assertNotIn(entity[source_id], validator.volgnummers)
+            self.assertFalse(validator.end_date[entity[source_id]])
+            mock_log_issue.assert_not_called()

--- a/src/tests/test_import_client.py
+++ b/src/tests/test_import_client.py
@@ -106,6 +106,24 @@ class TestImportClient(TestCase):
         self.assertEqual(len(_self.logger.info.call_args_list), 3)
 
     @patch('gobimport.import_client.Reader')
+    def test_import_rows_merged(self, mock_Reader):
+        mock_reader = MagicMock()
+        mock_Reader.return_value = mock_reader
+        rows = ((1, 2), (3, 4))
+        mock_reader.read.return_value = rows
+
+        progress = MagicMock()
+        write = MagicMock()
+
+        _self = MagicMock()
+        _self.converter.convert.return_value = 'Entity'
+
+        _self.merger.is_merged = lambda x: True
+
+        ImportClient.import_rows(_self, write, progress)
+        _self.entity_validator.validate.assert_called_with("Entity", merged=True)
+
+    @patch('gobimport.import_client.Reader')
     def test_import_row_too_few_records(self, mock_Reader):
         reader = MagicMock()
         mock_Reader.return_value = reader

--- a/src/tests/test_merger.py
+++ b/src/tests/test_merger.py
@@ -116,6 +116,23 @@ class TestMerger(unittest.TestCase):
         }, merge_def)
         self.assertEqual(len(merger.merge_items["b"]["entities"]), 2)
 
+    def test_is_merged(self):
+        merger = Merger(None)
+        entity = {"b": "value2", "volgnummer": 1}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merge_def = {"on": "b"}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merged = {"value2"}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merge_items["value2"] = {"entities": []}
+        self.assertFalse(merger.is_merged(entity))
+
+        merger.merge_items["value2"] = {"entities": [entity]}
+        self.assertTrue(merger.is_merged(entity))
+
     @mock.patch('gobimport.merger.get_import_definition_by_filename', mock.MagicMock())
     def test_merge(self):
         mock_client = mock.MagicMock(spec=ImportClient)
@@ -152,6 +169,3 @@ class TestMerger(unittest.TestCase):
         self.assertIsNone(merger.merge_items.get(1))
         self.assertIsNone(merger.merge_items.get(2))
         self.assertEqual(len(finished), 1)
-
-    def test_finish(self):
-        pass


### PR DESCRIPTION
* Drop merged entity from EntityValidator

* Update config v0.8.2

* Return early during validate instead of drop

* Add tests validate merged

* Silence test warning