### PR TITLE
Add standard code checks to repo

### DIFF
--- a/src/.flake8
+++ b/src/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 exclude = __pycache__
 max-complexity = 6
-max-line-length = 119
+max-line-length = 100
 show_source = True

--- a/src/.flake8
+++ b/src/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-exclude = __pycache__
-max-complexity = 6
-max-line-length = 100
-show_source = True

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -51,7 +51,7 @@ RUN rm -rf /app/src/gobcore/tests
 RUN rm -rf /app/src/gobconfig/tests
 
 # Copy test module and tests.
-COPY test.sh .flake8 pytest.ini ./
+COPY test.sh pyproject.toml ./
 COPY tests tests
 
 # Copy Jenkins files.

--- a/src/gobimport/__init__.py
+++ b/src/gobimport/__init__.py
@@ -1,2 +1,3 @@
 from gobcore.model import GOBModel
+
 gob_model = GOBModel()

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,15 +1,6 @@
 [tool.black]
 line-length = 120
 
-[tool.coverage.run]
-omit = [
-    "tests/*",
-    "**/GOB-Core/*",
-    "**/GOB-Config/*",
-    "**/gobcore/*",
-    "**/gobconfig/*"
-]
-
 [tool.coverage.report]
 show_missing = true
 exclude_lines = [
@@ -31,14 +22,7 @@ exclude_lines = [
 ]
 
 [tool.flake8]
-exclude = [
-    ".git",
-    "__pycache__",
-    ".mypy_cache",
-    ".pytest",
-    "venv",
-    "tests"
-]
+exclude = ["tests"]
 max-complexity = 6
 max-line-length = 120
 show_source = true
@@ -60,6 +44,7 @@ line_length = 120
 [tool.mypy]
 follow_imports = "normal"
 pretty = true
+cache_dir = "/tmp/.mypy_cache"
 
 # These options below can be replaced by 'strict = true' when all true
 # Start off with these

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,58 @@
+[tool.mypy]
+follow_imports = "normal"
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+pretty = true
+
+# to be switched to true
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+
+[[tool.mypy.overrides]]
+module = ["gobcore.*", "gobconfig.*"]
+ignore_missing_imports = true
+
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+line_length = 100
+
+[tool.black]
+line-length = 100
+
+[tool.coverage.run]
+branch = false
+omit = ["tests/*", "**/GOB-Core/*", "**/GOB-Config/*"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
+
+    # ignore type checking
+    "if TYPE_CHECKING:",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if __name__ == .__main__.:",
+
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod"
+]
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+cache_dir = "/tmp/.pytest_cache"
+addopts = [
+    "-vv",
+    "--doctest-modules",
+    "--cache-clear"
+]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,31 +1,7 @@
-[tool.mypy]
-follow_imports = "normal"
-warn_redundant_casts = true
-warn_unused_ignores = true
-disallow_any_generics = true
-check_untyped_defs = true
-no_implicit_reexport = true
-pretty = true
-
-# to be switched to true
-disallow_incomplete_defs = false
-disallow_untyped_defs = false
-disallow_untyped_calls = false
-
-[[tool.mypy.overrides]]
-module = ["gobcore.*", "gobconfig.*"]
-ignore_missing_imports = true
-
-[tool.isort]
-profile = "black"
-skip_gitignore = true
-line_length = 100
-
 [tool.black]
-line-length = 100
+line-length = 120
 
 [tool.coverage.run]
-branch = false
 omit = ["tests/*", "**/GOB-Core/*", "**/GOB-Config/*"]
 
 [tool.coverage.report]
@@ -48,15 +24,6 @@ exclude_lines = [
     "@(abc\\.)?abstractmethod"
 ]
 
-[tool.pytest.ini_options]
-testpaths = "tests"
-cache_dir = "/tmp/.pytest_cache"
-addopts = [
-    "-vv",
-    "--doctest-modules",
-    "--cache-clear"
-]
-
 [tool.flake8]
 exclude = [
     ".git",
@@ -67,7 +34,7 @@ exclude = [
     "tests"
 ]
 max-complexity = 6
-max-line-length = 100
+max-line-length = 120
 show_source = true
 ignore = [
     # Missing docstring in __init__
@@ -78,4 +45,57 @@ ignore = [
     "D100",
     # line break before binary operator
     "W503"
+]
+
+[tool.isort]
+profile = "black"
+line_length = 120
+
+[tool.mypy]
+follow_imports = "normal"
+pretty = true
+
+# These options below can be replaced by 'strict = true' when all true
+# Start off with these
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+
+# Getting these passing should be easy
+strict_equality = true
+strict_concatenate = true
+
+# Strongly recommend enabling this one as soon as you can
+check_untyped_defs = true
+
+# These shouldn't be too much additional work, but may be tricky to
+# get passing if you use a lot of untyped libraries
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+
+# These next few are various gradations of forcing use of type annotations
+disallow_untyped_calls = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+# This one isn't too hard to get passing, but return on investment is lower
+no_implicit_reexport = true
+
+# This one can be tricky to get passing if you use a lot of untyped libraries
+warn_return_any = true
+
+# disable import checks for gobcore and gobconfig
+[[tool.mypy.overrides]]
+module = ["gobcore.*", "gobconfig.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+cache_dir = "/tmp/.pytest_cache"
+addopts = [
+    "-vv",
+    "--doctest-modules",
+    "--cache-clear"
 ]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -2,7 +2,13 @@
 line-length = 120
 
 [tool.coverage.run]
-omit = ["tests/*", "**/GOB-Core/*", "**/GOB-Config/*"]
+omit = [
+    "tests/*",
+    "**/GOB-Core/*",
+    "**/GOB-Config/*",
+    "**/gobcore/*",
+    "**/gobconfig/*"
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -58,8 +58,24 @@ addopts = [
 ]
 
 [tool.flake8]
-exclude = "__pycache__"
+exclude = [
+    ".git",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest",
+    "venv",
+    "tests"
+]
 max-complexity = 6
 max-line-length = 100
 show_source = true
-count = true
+ignore = [
+    # Missing docstring in __init__
+    "D107",
+    # Missing docstring in public package
+    "D104",
+    # Missing docstring in module
+    "D100",
+    # line break before binary operator
+    "W503"
+]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -56,3 +56,10 @@ addopts = [
     "--doctest-modules",
     "--cache-clear"
 ]
+
+[tool.flake8]
+exclude = "__pycache__"
+max-complexity = 6
+max-line-length = 100
+show_source = true
+count = true

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-# writable by datapunt.
-cache_dir = /tmp/.pytest_cache

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.10#egg=gobconfig
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.1.2#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.3.0#egg=gobcore

--- a/src/test.sh
+++ b/src/test.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
+set -e
+set -u
 
-set -u # crash on missing env
-set -e # stop on any error
+export COVERAGE_FILE="/tmp/.coverage"
 
-# Coverage 6: coverage run --data-file=/tmp/.coveragerc …
-export COVERAGE_FILE=/tmp/.coverage
+echo "Running mypy"
+mypy gobimport
 
 echo "Running unit tests"
-coverage run --source=./gobimport -m pytest tests/
+coverage run -m pytest
 
-echo "Coverage report"
-coverage report --show-missing --fail-under=96
+echo "Reporting coverage"
+coverage report --fail-under=96
 
-echo "Running style checks"
-flake8 ./gobimport
+echo "Check if black finds no potential reformat fixes"
+black --check gobimport
+
+echo "Check for potential import sort"
+isort --check --diff gobimport
+
+echo "Running flake8"
+flake8 gobimport
+
+echo "Checks complete"

--- a/src/test.sh
+++ b/src/test.sh
@@ -4,8 +4,32 @@ set -u
 
 export COVERAGE_FILE="/tmp/.coverage"
 
+# Uncomment files to pass through checks
+FILES=(
+#  "gobimport/enricher/bag.py"
+#  "gobimport/enricher/meetbouten.py"
+#  "gobimport/enricher/test_catalogue.py"
+#  "gobimport/enricher/__init__.py"
+#  "gobimport/enricher/enricher.py"
+#  "gobimport/enricher/gebieden.py"
+#  "gobimport/entity_validator/bag.py"
+#  "gobimport/entity_validator/__init__.py"
+#  "gobimport/entity_validator/gebieden.py"
+#  "gobimport/entity_validator/state.py"
+#  "gobimport/validator/config.py"
+#  "gobimport/validator/__init__.py"
+#  "gobimport/converter.py"
+  "gobimport/__init__.py"
+#  "gobimport/import_client.py"
+#  "gobimport/reader.py"
+#  "gobimport/utils.py"
+#  "gobimport/injections.py"
+#  "gobimport/__main__.py"
+#  "gobimport/merger.py"
+)
+
 echo "Running mypy"
-mypy gobimport
+mypy "${FILES[@]}"
 
 echo "Running unit tests"
 coverage run -m pytest
@@ -14,12 +38,12 @@ echo "Reporting coverage"
 coverage report --fail-under=96
 
 echo "Check if black finds no potential reformat fixes"
-black --check gobimport
+black --verbose --check "${FILES[@]}"
 
 echo "Check for potential import sort"
-isort --check --diff gobimport
+isort --check --diff "${FILES[@]}"
 
 echo "Running flake8"
-flake8 gobimport
+flake8 "${FILES[@]}"
 
 echo "Checks complete"

--- a/src/test.sh
+++ b/src/test.sh
@@ -32,7 +32,7 @@ echo "Running mypy"
 mypy "${FILES[@]}"
 
 echo "Running unit tests"
-coverage run -m pytest
+coverage run --source=gobimport -m pytest
 
 echo "Reporting coverage"
 coverage report --fail-under=96


### PR DESCRIPTION
- pyproject.toml is set up as a generic file we can use in any other repo
- requires flake8-pyproject package in gobcore
- Uncomment/enable checks per file in test.sh

included checks
- mypy
- pytest
- coverage
- black
- isort
- flake8

depends on https://github.com/Amsterdam/GOB-Core/pull/703