### PR TITLE
Update Config to v0.19.0 with BRK2 ADB imports

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/Amsterdam/GOB-Config.git@v0.18.0
+git+https://github.com/Amsterdam/GOB-Config.git@v0.19.0
 git+https://github.com/Amsterdam/GOB-Core.git@v2.28.1


### PR DESCRIPTION
Release v0.19.0 will be created from PR https://github.com/Amsterdam/GOB-Config/pull/188